### PR TITLE
fix: match collector filters on the parsed tag, not the raw custom_id

### DIFF
--- a/src/commands/tournament.ts
+++ b/src/commands/tournament.ts
@@ -4,13 +4,15 @@ import {
   ButtonInteraction,
   ButtonStyle,
   ComponentType,
+  Message,
   SlashCommandBuilder,
   StringSelectMenuBuilder,
+  StringSelectMenuInteraction,
 } from 'discord.js';
 import { buildThreadName, getDraftLinksMarkdown } from '../util.ts';
 import { runGuarded, safeDefer, safeInteractionError } from '../interactionSafety.ts';
 import { User } from '../interfaces.ts';
-import { createButton, createButtonData, parseButtonData, seriesDataFits, ButtonData } from '../buttons/button.ts';
+import { createButton, createButtonData, parseButtonData, seriesDataFits } from '../buttons/button.ts';
 import { createGame, getEvent, getEvents, getEventWithTeams, getSeriesId, getTeam, getTotalGames, Team } from '../dennys.ts';
 import log from 'loglevel';
 import { SeriesData } from '../types/toddData.ts';
@@ -22,9 +24,15 @@ async function grabTeams(divisionId: number): Promise<Team[]> {
   const teams = event?.teams || [];
   return teams;
 }
-// TODO: we should NOT use any here if we know what it's going to be.
-// i don't know what it is going to be LMFAO
-export async function handleDivisionSelect(interaction: any, message: any) {
+/**
+ * `message` is what `editReply` handed back when the division dropdown was
+ * posted - we only keep it to hang the next collector off, and it is the same
+ * message the team/stage dropdowns replace.
+ */
+export async function handleDivisionSelect(
+  interaction: StringSelectMenuInteraction,
+  message: Message,
+) {
   logger.info('Handling division select interaction: ' + interaction.customId);
   const data = parseButtonData(interaction.customId);
   const seriesData = data.seriesData;
@@ -88,19 +96,28 @@ export async function handleDivisionSelect(interaction: any, message: any) {
   const collector = message.createMessageComponentCollector({
     componentType: ComponentType.StringSelect,
     filter: (i: { user: User; customId: string }) =>
-      i.user === interaction.user && ['team1_select', 'team2_select', 'stage_select'].includes(parseButtonData(i.customId).tag),
+      i.user.id === interaction.user.id && ['team1_select', 'team2_select', 'stage_select'].includes(parseButtonData(i.customId).tag),
     time: 5 * 60 * 1000,
   });
 
-  collector.on('collect', async (interaction: any) => {
+  collector.on('collect', async (interaction: StringSelectMenuInteraction) => {
     logger.info('Collecting team select interaction:', interaction.customId);
     // Must be awaited inside a guard - an un-awaited reject here took the bot down.
     await runGuarded(interaction, 'team_select', () => handleTeamSelect(interaction));
   });
 }
 
-export async function handleTeamSelect(interaction: any) {
-  const { values, user } = interaction;
+/**
+ * Re-renders the selection step. Reached two ways: from the three dropdowns,
+ * and from the Switch Sides / Cancel buttons that `getButtonHandler` routes
+ * here - which is why the parameter is a union. Only the dropdown path carries
+ * `values`; the buttons act purely on the tag.
+ */
+export async function handleTeamSelect(
+  interaction: StringSelectMenuInteraction | ButtonInteraction,
+) {
+  const { user } = interaction;
+  const values = interaction.isStringSelectMenu() ? interaction.values : [];
   const data = parseButtonData(interaction.customId);
   const seriesData = data.seriesData;
   let team1 = seriesData.team1Id;
@@ -533,8 +550,11 @@ module.exports =  {
     });
     const collector = message.createMessageComponentCollector({
       componentType: ComponentType.StringSelect,
+      // Match on the parsed tag, not the raw id: custom_ids carry the compressed
+      // wire code ('d'), so a startsWith on the readable name never matches and
+      // the select goes unacked until Discord's 3s deadline kills it.
       filter: (i: { user: User; customId: string }) =>
-        i.user === interaction.user && i.customId.startsWith('division_select'),
+        i.user.id === interaction.user.id && parseButtonData(i.customId).tag === 'division_select',
       time: 5 * 60 * 1000,
     });
 

--- a/test/collectorFilters.test.ts
+++ b/test/collectorFilters.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Message } from 'discord.js';
+import { createButtonData } from '../src/buttons/button.ts';
+import { SeriesData } from '../src/types/toddData.ts';
+
+/**
+ * The two `createMessageComponentCollector` filters in tournament.ts are the
+ * only thing that acknowledges a select menu. If a filter never matches, the
+ * collector never fires, nothing calls deferUpdate(), and the user gets
+ * "Todd didn't respond in time" after Discord's 3 second deadline - with no
+ * error in the logs, because no handler ever ran.
+ *
+ * That is exactly what happened: the division filter matched on
+ * `customId.startsWith('division_select')`, but custom_ids carry the compressed
+ * wire code from TAG_CODES ('d'), not the readable tag. The filter was
+ * permanently false and /start-series died at the first dropdown.
+ *
+ * So these tests feed each filter a custom_id built the same way production
+ * builds it - `createButtonData(...).serialize()` - rather than a hand-written
+ * string. A hand-written id would have passed the broken filter too.
+ */
+
+vi.mock('../src/dennys.ts', () => ({
+  getEvents: vi.fn(async () => [
+    { id: 7, name: 'Division A' },
+    { id: 8, name: 'Division B' },
+  ]),
+  getEvent: vi.fn(async (id: number) => ({
+    id,
+    name: 'Division A',
+    eventStages: ['REGULAR_SEASON'],
+  })),
+  getEventWithTeams: vi.fn(async (id: number) => ({
+    id,
+    name: 'Division A',
+    eventStages: ['REGULAR_SEASON'],
+    teams: [
+      { id: 11, name: 'Team 11', logo: null, eventId: id },
+      { id: 22, name: 'Team 22', logo: null, eventId: id },
+    ],
+  })),
+  getTeam: vi.fn(),
+  getSeriesId: vi.fn(),
+  getTotalGames: vi.fn(),
+  createGame: vi.fn(),
+}));
+
+const tournament = await import('../src/commands/tournament.ts');
+const { handleDivisionSelect } = tournament;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const execute = (tournament as any).execute as (i: unknown, id: number | null) => Promise<void>;
+
+const USER = '123456789012345678';
+const STRANGER = '999999999999999999';
+const EVENT_GROUP_ID = 42;
+
+const seriesData: SeriesData = {
+  enemyCaptainId: '223456789012345678',
+  divisionId: 7,
+  team1Id: 11,
+  team2Id: 22,
+  stage: 'REGULAR_SEASON',
+};
+
+/** A custom_id exactly as production would mint it, compressed tag and all. */
+type ComponentInteraction = { user: { id: string }; customId: string };
+function idFor(tag: string): ComponentInteraction {
+  return { user: { id: USER }, customId: createButtonData(tag, USER, seriesData).serialize() };
+}
+
+type CollectorFilter = (i: ComponentInteraction) => boolean;
+
+/** Captures whatever filter the code under test hands to its collector. */
+let capturedFilter: CollectorFilter | null = null;
+
+const fakeMessage = {
+  createMessageComponentCollector: vi.fn((opts: { filter: CollectorFilter }) => {
+    capturedFilter = opts.filter;
+    return { on: vi.fn() };
+  }),
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeInteraction(overrides: Record<string, unknown> = {}): any {
+  const interaction = {
+    user: { id: USER },
+    values: [] as string[],
+    customId: '',
+    replied: false,
+    deferred: false,
+    isRepliable: () => true,
+    isMessageComponent: () => true,
+    options: { getUser: () => ({ id: seriesData.enemyCaptainId }) },
+    deferReply: vi.fn(async () => {
+      interaction.deferred = true;
+    }),
+    deferUpdate: vi.fn(async () => {
+      interaction.deferred = true;
+    }),
+    editReply: vi.fn(async () => fakeMessage),
+    ...overrides,
+  };
+  return interaction;
+}
+
+beforeEach(() => {
+  capturedFilter = null;
+  fakeMessage.createMessageComponentCollector.mockClear();
+});
+
+/** Runs /start-series far enough to mint the division dropdown and its collector. */
+async function divisionFilter(): Promise<CollectorFilter> {
+  await execute(makeInteraction(), EVENT_GROUP_ID);
+  expect(fakeMessage.createMessageComponentCollector).toHaveBeenCalled();
+  return capturedFilter!;
+}
+
+/** Runs the division handler far enough to mint the team/stage collector. */
+async function teamStageFilter(): Promise<CollectorFilter> {
+  const interaction = makeInteraction({
+    customId: createButtonData('division_select', USER, seriesData).serialize(),
+    values: ['7'],
+  });
+  // A stand-in for the Message editReply returns: the handler only ever calls
+  // createMessageComponentCollector on it.
+  await handleDivisionSelect(interaction, fakeMessage as unknown as Message);
+  expect(fakeMessage.createMessageComponentCollector).toHaveBeenCalled();
+  return capturedFilter!;
+}
+
+describe('the division_select collector filter', () => {
+  it('matches a custom_id that createButtonData actually produced', async () => {
+    // The regression. This id begins with 'd:v1:', so any check against the
+    // readable tag name fails here and the select is never acknowledged.
+    const filter = await divisionFilter();
+    expect(filter(idFor('division_select'))).toBe(true);
+  });
+
+  it('is not fooled by the readable tag name appearing nowhere in the id', async () => {
+    // Pins the reason the old filter broke, so it cannot be reintroduced by
+    // someone reaching for startsWith again.
+    const { customId } = idFor('division_select');
+    expect(customId.startsWith('division_select')).toBe(false);
+    expect(customId.startsWith('d:')).toBe(true);
+  });
+
+  it('ignores another user clicking the same dropdown', async () => {
+    const filter = await divisionFilter();
+    expect(filter({ ...idFor('division_select'), user: { id: STRANGER } })).toBe(false);
+  });
+
+  it('ignores selects belonging to a later step of the flow', async () => {
+    const filter = await divisionFilter();
+    for (const tag of ['team1_select', 'team2_select', 'stage_select']) {
+      expect(filter(idFor(tag)), tag).toBe(false);
+    }
+  });
+});
+
+describe('the team/stage collector filter', () => {
+  it('matches every select the confirm step depends on', async () => {
+    const filter = await teamStageFilter();
+    for (const tag of ['team1_select', 'team2_select', 'stage_select']) {
+      expect(filter(idFor(tag)), tag).toBe(true);
+    }
+  });
+
+  it('ignores another user clicking the same dropdowns', async () => {
+    const filter = await teamStageFilter();
+    for (const tag of ['team1_select', 'team2_select', 'stage_select']) {
+      expect(filter({ ...idFor(tag), user: { id: STRANGER } }), tag).toBe(false);
+    }
+  });
+
+  it('ignores tags outside its step', async () => {
+    const filter = await teamStageFilter();
+    for (const tag of ['division_select', 'confirm', 'generate_another']) {
+      expect(filter(idFor(tag)), tag).toBe(false);
+    }
+  });
+});

--- a/test/tournament.test.ts
+++ b/test/tournament.test.ts
@@ -84,6 +84,8 @@ function makeInteraction(tag: string, data: SeriesData = seriesData, customId?: 
     deferred: false,
     isRepliable: () => true,
     isMessageComponent: () => true,
+    // Defaults to the dropdown path; the Switch Sides / Cancel buttons flip this.
+    isStringSelectMenu: () => true,
     guild: { members: { fetch: vi.fn(async () => ({ id: ORIGINAL_USER })) } },
     deferUpdate: vi.fn(async () => {
       calls.push('deferUpdate');
@@ -109,6 +111,19 @@ function makeInteraction(tag: string, data: SeriesData = seriesData, customId?: 
       calls.push('deleteReply');
     }),
   };
+  return interaction;
+}
+
+/**
+ * The Switch Sides and Cancel buttons reach `handleTeamSelect` too, routed
+ * there by `getButtonHandler`. A real ButtonInteraction has no `values` at all -
+ * modelled here by deleting it - so the handler must decide what it is holding
+ * rather than destructuring a property only the dropdowns carry.
+ */
+function makeButtonInteraction(tag: string, data: SeriesData = seriesData) {
+  const interaction = makeInteraction(tag, data);
+  interaction.isStringSelectMenu = () => false;
+  delete (interaction as { values?: string[] }).values;
   return interaction;
 }
 
@@ -214,6 +229,33 @@ describe('handleTeamSelect on the normal path', () => {
 
     expect(editReplyPayloads.at(-1)).toMatchObject({
       content: expect.stringContaining('Please confirm'),
+    });
+  });
+});
+
+describe('handleTeamSelect on the button path (no values to read)', () => {
+  it('swaps the sides for Switch Sides', async () => {
+    const interaction = makeButtonInteraction('switch');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleTeamSelect(interaction as any);
+
+    // Blue was 11 and red was 22 going in, so the confirm step must show them
+    // the other way round - and must get there without touching `values`.
+    expect(editReplyPayloads.at(-1)).toMatchObject({
+      content: expect.stringContaining('Blue Side: Team 22'),
+    });
+    expect(editReplyPayloads.at(-1)).toMatchObject({
+      content: expect.stringContaining('Red Side: Team 11'),
+    });
+  });
+
+  it('clears both teams and the stage for Cancel', async () => {
+    const interaction = makeButtonInteraction('cancel');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleTeamSelect(interaction as any);
+
+    expect(editReplyPayloads.at(-1)).toMatchObject({
+      content: expect.stringContaining('Not Selected!'),
     });
   });
 });


### PR DESCRIPTION
The division_select collector filtered on
`customId.startsWith('division_select')`, but custom_ids carry the compressed wire code from TAG_CODES (`d:v1:...`), not the readable tag. The filter was permanently false, so the collector never fired, nothing called deferUpdate(), and /start-series died at the first dropdown once Discord's 3s ack deadline passed.

Nothing surfaced in the logs because no handler ever ran - the only symptom was the absence of a "Collecting division select" line.

A repo-wide sweep found this was the only site affected: every other tag comparison already goes through parseButtonData, and the remaining raw comparisons (select_event_group, rankModal) are literal custom_ids that never pass through the encoder.

Also switches both filters from `i.user === interaction.user` to an id comparison. Object identity happens to work while discord.js has the user cached, but it is a latent version of the same class of bug.

Adds test/collectorFilters.test.ts, which builds its fixtures with createButtonData().serialize() rather than hand-written strings - a hand-written id would have passed the broken filter and proved nothing. Verified the suite fails when the old filter is restored.