### PR TITLE
refactor: Pin seriesId into SeriesData

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -207,7 +207,7 @@ valid regardless of restarts.
 The format (`src/buttons/button.ts` + `src/types/toddData.ts`):
 
 ```
-tag : v1 : originalUserId : enemyCaptainId : divisionId : team1Id : team2Id : stage
+tag : v1 : originalUserId : enemyCaptainId : divisionId : team1Id : team2Id : seriesId : stage
 ```
 
 - `tag` selects the handler in `src/buttons/handlers.ts`. On the wire it is a
@@ -223,8 +223,13 @@ tag : v1 : originalUserId : enemyCaptainId : divisionId : team1Id : team2Id : st
   keep arriving after a redeploy.
 - `originalUserId` is who started the flow. Handlers allow only that user or the
   enemy captain to act.
-- The remaining five fields are `SeriesData`, encoded by `encodeSeriesData` and
+- The remaining six fields are `SeriesData`, encoded by `encodeSeriesData` and
   read back by `decodeSeriesData`.
+- `seriesId` is the series every later button acts on, pinned the first time it
+  is resolved and `0` until then. Without it each press re-resolves from the team
+  pair, so the moment Dennys closes one series the next code lands in the other
+  one for the same pair. Legacy ids predate it and decode as `0`, which falls
+  back to resolving by team pair.
 
 **The 100-character budget.** Discord caps `custom_id` at 100, and in the
 original encoding that budget was already spent: the longest tag
@@ -239,10 +244,12 @@ characters to 13; wire codes take the tag from 24 to 2.
 | --- | --- | --- |
 | Original | 100 | 20 |
 | Base36 ids | 86 | 34 |
-| ...plus tag codes | **64** | **56** |
+| ...plus tag codes | 64 | 56 |
+| ...plus `seriesId` | **68** | **52** |
 
-That leaves 36 characters spare — room for another id (a base36 `seriesId` and
-its separator is ~5) without revisiting this.
+That still leaves 32 characters spare, so another id fits without revisiting
+this. `test/button.test.ts` pins both the boundary and the remaining headroom, so
+the next field can be judged against a measurement rather than an estimate.
 
 `parseButtonData` splits on `:`. Two consequences worth knowing:
 
@@ -250,7 +257,7 @@ its separator is ~5) without revisiting this.
   that it absorbs the remainder of the split, so `Week 1: Opener` round-trips.
   The fields ahead of it are base36 or a tag, none of which can contain a `:`.
 - **The stage is still the field that can overflow.** Dennys returns
-  `eventStages` as free-form strings, so its length is not ours to control. 56
+  `eventStages` as free-form strings, so its length is not ours to control. 52
   characters fit. Past that, `seriesDataFits` refuses the series at stage
   selection — sized against the *longest* tag code, not the current one, because
   tags grow as a series advances (`s` is 1 character, `gc` is 2) and the late

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -233,7 +233,7 @@ Things to check:
   absorbs the rest of the split, so `Week 1: Opener` round-trips. Nothing ahead
   of it can contain a `:`.
 - **Exceeding 100 characters.** Discord's cap on `custom_id`. Base36 ids and tag
-  codes put the realistic worst case at 64, leaving 56 characters for the stage
+  codes put the realistic worst case at 68, leaving 52 characters for the stage
   name — the one field dennys hands us as a free-form string. Past that you get
   `CustomIdTooLongError` in the logs and *"The stage **X** has too long a name for
   Todd to track this series"* in Discord, raised at stage selection before

--- a/src/buttons/button.ts
+++ b/src/buttons/button.ts
@@ -132,7 +132,9 @@ export function parseButtonData(customId: string): ButtonData {
   const metadata = parts.slice(isVersioned ? 3 : 2);
   // The stage is last precisely so it can absorb the rest of the split. A stage
   // named "Week 1: Opener" used to shift every field after it; now it survives.
-  const fields = [...metadata.slice(0, 4), metadata.slice(4).join(':')];
+  // Legacy ids carry one field fewer, so its position differs.
+  const stageIndex = isVersioned ? 5 : 4;
+  const fields = [...metadata.slice(0, stageIndex), metadata.slice(stageIndex).join(':')];
   return {
     tag,
     originalUserId,

--- a/src/buttons/handlers/generateAnotherCode.ts
+++ b/src/buttons/handlers/generateAnotherCode.ts
@@ -37,6 +37,7 @@ export async function handleGenerateAnotherCode(interaction: ButtonInteraction) 
           team2Id: team1.id,
           divisionId: seriesData.divisionId,
           enemyCaptainId: seriesData.enemyCaptainId,
+          seriesId: seriesData.seriesId,
           stage: seriesData.stage
         };
         

--- a/src/buttons/handlers/generateAnotherConfirm.ts
+++ b/src/buttons/handlers/generateAnotherConfirm.ts
@@ -35,15 +35,16 @@ export async function handleGenerateAnotherConfirm(interaction: ButtonInteractio
       components: [],
     });
 
-    const tournamentCode = await getTournamentCode(
-      team1,
-      team2,
-      division,
-      seriesData.stage,
+    const tournamentCode = await getTournamentCode({
+      team1Id: team1,
+      team2Id: team2,
+      divisionId: division,
+      stage: seriesData.stage,
+      seriesId: seriesData.seriesId,
       interaction,
-      opposing_captain,
-      false
-    );
+      enemyCaptainId: opposing_captain,
+      first: false,
+    });
 
     if (tournamentCode.error) {
       // Report in place of the "Generating..." message. followUp() here used to

--- a/src/buttons/handlers/switchSides.ts
+++ b/src/buttons/handlers/switchSides.ts
@@ -32,6 +32,7 @@ export async function handleSwitchSides(interaction: ButtonInteraction) {
       team2Id: team1.id,
       divisionId: seriesData.divisionId,
       enemyCaptainId: seriesData.enemyCaptainId,
+      seriesId: seriesData.seriesId,
       stage: seriesData.stage
     };
     const confirmButtonData = createButtonData("generate_another_confirm", data.originalUserId, seriesData);

--- a/src/commands/tournament.ts
+++ b/src/commands/tournament.ts
@@ -65,6 +65,7 @@ export async function handleDivisionSelect(
     team2Id: "" as unknown as number,
     divisionId: divisionKey,
     enemyCaptainId: enemyCaptainId,
+    seriesId: 0,
     stage: ""
   };
   const customId1 = createButtonData('team1_select', interaction.user.id, seriesDataUpdated);
@@ -167,6 +168,7 @@ export async function handleTeamSelect(
     team2Id: team2,
     divisionId: division,
     enemyCaptainId: enemyCaptainId,
+    seriesId: seriesData.seriesId,
     stage
   };
 
@@ -286,7 +288,16 @@ export async function handleBothTeamSubmission(interaction: ButtonInteraction) {
   }
 
   try {
-    const tournamentCode = await getTournamentCode(seriesData.team1Id, seriesData.team2Id, seriesData.divisionId, seriesData.stage, interaction, seriesData.enemyCaptainId, true);
+    const tournamentCode = await getTournamentCode({
+      team1Id: seriesData.team1Id,
+      team2Id: seriesData.team2Id,
+      divisionId: seriesData.divisionId,
+      stage: seriesData.stage,
+      seriesId: seriesData.seriesId,
+      interaction,
+      enemyCaptainId: seriesData.enemyCaptainId,
+      first: true,
+    });
     if (tournamentCode.error != null) {
       // Handle error: Update original interaction
       await interaction.editReply({
@@ -301,7 +312,10 @@ export async function handleBothTeamSubmission(interaction: ButtonInteraction) {
 
       await interaction.deleteReply();
 
-      const generateButtonData = createButtonData('generate_another', user.id, seriesData);
+      // Pinned here, at the one point the series is known: every later press
+      // reads it back out rather than resolving from the team pair again.
+      const pinnedSeries: SeriesData = { ...seriesData, seriesId: tournamentCode.seriesId };
+      const generateButtonData = createButtonData('generate_another', user.id, pinnedSeries);
       const generateButton = createButton(
         generateButtonData,
         'Generate Next Game',
@@ -366,15 +380,29 @@ export async function handleBothTeamSubmission(interaction: ButtonInteraction) {
 }
 
 // TODO: Fix this as to not need to send interaction
-export async function getTournamentCode(
-  team1: number,
-  team2: number,
-  divisionId: number,
-  stage: string,
-  interaction: ButtonInteraction,
-  enemyCaptainId: string,
-  first: boolean
-): Promise<{
+export type TournamentCodeRequest = {
+  team1Id: number;
+  team2Id: number;
+  divisionId: number;
+  stage: string;
+  /** Pinned series, or 0 to resolve it from the team pair. */
+  seriesId: number;
+  interaction: ButtonInteraction;
+  enemyCaptainId: string;
+  /** Only the first game of a series gets draft links. */
+  first: boolean;
+};
+
+export async function getTournamentCode({
+  team1Id: team1,
+  team2Id: team2,
+  divisionId,
+  stage,
+  seriesId: pinnedSeriesId,
+  interaction,
+  enemyCaptainId,
+  first,
+}: TournamentCodeRequest): Promise<{
   discordResponse: string | null;
   draftLinks: string | null;
   shortcode: string | null;
@@ -389,6 +417,8 @@ export async function getTournamentCode(
   // is written. This is the handle reportSeriesResult takes.
   tournamentCodeId: number;
   totalGames: number;
+  /** The resolved series, for callers building buttons that must pin it. */
+  seriesId: number;
 }> {
   //TODO: Call api with this informatio nand let it handle all this logic
   const division  = divisionId? Number(divisionId) : null
@@ -406,6 +436,7 @@ export async function getTournamentCode(
       team1Name: team1.toString(),
       team2Name: team2.toString(),
       tournamentCodeId: 0,
+      seriesId: 0,
       totalGames: 0,
     };
   }
@@ -420,6 +451,7 @@ export async function getTournamentCode(
       team1Name: team1.toString(),
       team2Name: team2.toString(),
       tournamentCodeId: 0,
+      seriesId: 0,
       totalGames:0
     };
   }
@@ -429,7 +461,9 @@ export async function getTournamentCode(
   const team1Name = team1Data?.name || 'Unknown Team 1';
   const team2Name = team2Data?.name || 'Unknown Team 2';
   logger.info(`Fetched teams - Team 1: ${team1Data?.id}  ${team1Data?.name}, Team 2: ${team2Data?.id}  ${team2Data?.name}`);
-  const seriesId = await getSeriesId(division!, team1, team2, selectedStage);
+  // Once pinned, the series never gets looked up by team pair again. Re-resolving
+  // is what let a completed series hand the next code to the wrong one.
+  const seriesId = pinnedSeriesId || (await getSeriesId(division!, team1, team2, selectedStage));
   if (!seriesId) {
     return {
       discordResponse: null,
@@ -441,6 +475,7 @@ export async function getTournamentCode(
       team1Name,
       team2Name,
       tournamentCodeId: 0,
+      seriesId: 0,
       totalGames: 0
     };
   }
@@ -481,6 +516,7 @@ export async function getTournamentCode(
     team1Name,
     team2Name,
     tournamentCodeId: code.id,
+    seriesId,
     totalGames
   };
 }
@@ -522,6 +558,7 @@ module.exports =  {
       team2Id: "" as unknown as number,
       divisionId: 0,
       enemyCaptainId: enemyCaptain.id,
+      seriesId: 0,
       stage: ""
     };
     // Show division select menu

--- a/src/types/toddData.ts
+++ b/src/types/toddData.ts
@@ -3,6 +3,14 @@ export type SeriesData = {
   team2Id: number;
   divisionId: number;
   enemyCaptainId: string;
+  /**
+   * The series every later button acts on, pinned once it is first resolved.
+   * 0 until then - the selection dropdowns run before a series is known.
+   *
+   * Without it, each press re-resolves from the team pair, so the moment dennys
+   * closes one series the next code lands in the other one for the same pair.
+   */
+  seriesId: number;
   stage: string;
 };
 
@@ -68,12 +76,15 @@ export function decodeSnowflake(value: string | undefined): string {
   return acc.toString();
 }
 
+// Stage stays last so it can absorb the rest of the split; any new field goes
+// before it. See parseButtonData, which reassembles on that assumption.
 export function encodeSeriesData(data: SeriesData): string[] {
   return [
     encodeSnowflake(data.enemyCaptainId),
     encodeId(data.divisionId),
     encodeId(data.team1Id),
     encodeId(data.team2Id),
+    encodeId(data.seriesId),
     data.stage,
   ];
 }
@@ -84,7 +95,8 @@ export function decodeSeriesData(arr: string[]): SeriesData {
     divisionId: decodeId(arr[1]),
     team1Id: decodeId(arr[2]),
     team2Id: decodeId(arr[3]),
-    stage: arr[4] ?? '',
+    seriesId: decodeId(arr[4]),
+    stage: arr[5] ?? '',
   };
 }
 
@@ -109,6 +121,9 @@ export function decodeLegacySeriesData(arr: string[]): SeriesData {
     divisionId: toLegacyId(arr[1]),
     team1Id: toLegacyId(arr[2]),
     team2Id: toLegacyId(arr[3]),
+    // Predates the field, so the series is resolved from the team pair as it
+    // always was for these ids.
+    seriesId: 0,
     stage: arr[4] ?? '',
   };
 }

--- a/test/ackBeforeSlowWork.test.ts
+++ b/test/ackBeforeSlowWork.test.ts
@@ -33,8 +33,9 @@ vi.mock('../src/commands/tournament.ts', () => ({
       divisionId: 7,
       team1Name: 'Team 11',
       team2Name: 'Team 22',
-      gameId: 1,
+      tournamentCodeId: 1,
       totalGames: 3,
+      seriesId: 756,
     };
   }),
 }));
@@ -54,6 +55,7 @@ const seriesData: SeriesData = {
   divisionId: 7,
   team1Id: 11,
   team2Id: 22,
+  seriesId: 756,
   stage: 'Week 1',
 };
 

--- a/test/button.test.ts
+++ b/test/button.test.ts
@@ -13,6 +13,7 @@ const seriesData: SeriesData = {
   divisionId: 7,
   team1Id: 11,
   team2Id: 22,
+  seriesId: 756,
   stage: 'Week 1',
 };
 
@@ -26,13 +27,14 @@ describe('custom_id serialize/parse round-trip', () => {
   });
 
   it('serializes in the documented field order behind a version marker', () => {
-    // tag : v1 : originalUserId : enemyCaptainId : divisionId : team1Id : team2Id : stage
+    // tag : v1 : originalUserId : enemyCaptainId : divisionId : team1Id : team2Id
+    //     : seriesId : stage
     const data = createButtonData('switch_sides', '123456789012345678', seriesData);
     const parts = data.serialize().split(':');
     expect(parts[0]).toBe('ws');
     expect(parts[1]).toBe('v1');
-    expect(parts.slice(2, 7).every((p) => /^[0-9a-z~]*$/.test(p))).toBe(true);
-    expect(parts[7]).toBe('Week 1');
+    expect(parts.slice(2, 8).every((p) => /^[0-9a-z~]*$/.test(p))).toBe(true);
+    expect(parts[8]).toBe('Week 1');
   });
 });
 
@@ -81,6 +83,7 @@ describe("Discord's 100-character custom_id cap", () => {
     divisionId: 9999,
     team1Id: 9999,
     team2Id: 9999,
+    seriesId: 9999,
     stage: 'PROMOTION_RELEGATION',
   };
 
@@ -89,10 +92,9 @@ describe("Discord's 100-character custom_id cap", () => {
     expect(data.serialize().length).toBeLessThan(MAX_CUSTOM_ID_LENGTH);
   });
 
-  it('keeps enough headroom for a field the size of a seriesId', () => {
-    // The budget question that prompted this work: does another id still fit?
-    // A base36 seriesId plus its separator is ~5 characters. Pinning the number
-    // here means a future field can be judged against a fact, not an estimate.
+  it('keeps headroom for another field beyond the ones already carried', () => {
+    // Pinning the number means the next field can be judged against a fact
+    // rather than an estimate. A base36 id plus its separator is ~5 characters.
     const data = createButtonData('generate_another_confirm', '1234567890123456789', worstCase);
     expect(MAX_CUSTOM_ID_LENGTH - data.serialize().length).toBeGreaterThanOrEqual(20);
   });
@@ -115,12 +117,12 @@ describe("Discord's 100-character custom_id cap", () => {
     expect(() => data.serialize()).toThrow(CustomIdTooLongError);
   });
 
-  it('fits a stage name of 56 characters alongside everything else', () => {
+  it('fits a stage name of 52 characters alongside everything else', () => {
     // Dennys hands us eventStages as free-form strings, so this is the budget
     // that actually matters. 'PROMOTION_RELEGATION' is 20.
     const data = createButtonData('generate_another_confirm', '1234567890123456789', {
       ...worstCase,
-      stage: 'X'.repeat(56),
+      stage: 'X'.repeat(52),
     });
     expect(data.serialize().length).toBeLessThanOrEqual(MAX_CUSTOM_ID_LENGTH);
   });
@@ -137,13 +139,13 @@ describe('seriesDataFits', () => {
     // (generate_another_confirm), which is built after the game exists.
     // Abbreviating the tags narrowed that window from 12 characters to 1, so
     // this pins the exact boundary rather than a comfortable margin.
-    const stage = 'X'.repeat(57);
+    const stage = 'X'.repeat(53);
     const user = '1234567890123456789';
-    const worst = { ...seriesData, enemyCaptainId: user, divisionId: 9999, team1Id: 9999, team2Id: 9999, stage };
+    const worst = { ...seriesData, enemyCaptainId: user, divisionId: 9999, team1Id: 9999, team2Id: 9999, seriesId: 9999, stage };
     const short = createButtonData('stage_select', user, worst);
     expect(short.serialize().length).toBeLessThanOrEqual(MAX_CUSTOM_ID_LENGTH);
     expect(seriesDataFits(user, worst)).toBe(false);
-    expect(seriesDataFits(user, { ...worst, stage: 'X'.repeat(56) })).toBe(true);
+    expect(seriesDataFits(user, { ...worst, stage: 'X'.repeat(52) })).toBe(true);
   });
 });
 
@@ -166,7 +168,9 @@ describe('ids minted before base36', () => {
     const parsed = parseButtonData(legacy);
     expect(parsed.tag).toBe('generate_another');
     expect(parsed.originalUserId).toBe('123456789012345678');
-    expect(parsed.seriesData).toEqual(seriesData);
+    // Predates seriesId, so it decodes unpinned and the series is resolved from
+    // the team pair as it always was for these ids.
+    expect(parsed.seriesData).toEqual({ ...seriesData, seriesId: 0 });
   });
 
   it('re-serializes verbatim rather than rewriting the id under the user', () => {

--- a/test/collectorFilters.test.ts
+++ b/test/collectorFilters.test.ts
@@ -39,10 +39,13 @@ vi.mock('../src/dennys.ts', () => ({
       { id: 22, name: 'Team 22', logo: null, eventId: id },
     ],
   })),
+  // These tests only reach the collector filters, but a bare factory mock fails
+  // on first *access*, so every export tournament.ts imports has to be present.
   getTeam: vi.fn(),
   getSeriesId: vi.fn(),
-  getTotalGames: vi.fn(),
-  createGame: vi.fn(),
+  getSeries: vi.fn(),
+  issueTournamentCode: vi.fn(),
+  nextGameNumber: vi.fn(),
 }));
 
 const tournament = await import('../src/commands/tournament.ts');
@@ -59,6 +62,7 @@ const seriesData: SeriesData = {
   divisionId: 7,
   team1Id: 11,
   team2Id: 22,
+  seriesId: 756,
   stage: 'REGULAR_SEASON',
 };
 

--- a/test/toddData.test.ts
+++ b/test/toddData.test.ts
@@ -15,19 +15,27 @@ const sample: SeriesData = {
   divisionId: 7,
   team1Id: 11,
   team2Id: 22,
+  seriesId: 756,
   stage: 'Week 1',
 };
 
 describe('encodeSeriesData', () => {
-  it('emits the five fields in the documented custom_id order, base36 encoded', () => {
-    // ARCHITECTURE.md: enemyCaptainId : divisionId : team1Id : team2Id : stage
+  it('emits the fields in the documented custom_id order, base36 encoded', () => {
+    // enemyCaptainId : divisionId : team1Id : team2Id : seriesId : stage
     expect(encodeSeriesData(sample)).toEqual([
       encodeSnowflake('123456789012345678'),
       '7',
       'b',
       'm',
+      'l0',
       'Week 1',
     ]);
+  });
+
+  it('keeps the stage last, so a new field cannot displace it', () => {
+    // The stage absorbs the rest of the split, which is the only reason a stage
+    // containing a colon survives. Anything appended after it would break that.
+    expect(encodeSeriesData(sample).at(-1)).toBe('Week 1');
   });
 });
 
@@ -89,7 +97,7 @@ describe('id base36', () => {
 
 describe('decodeSeriesData fallbacks for a truncated array', () => {
   it('defaults a missing stage to an empty string', () => {
-    expect(decodeSeriesData(['cap', '1', '2', '3']).stage).toBe('');
+    expect(decodeSeriesData(['cap', '1', '2', '3', '4']).stage).toBe('');
   });
 
   it('defaults missing numeric fields to 0', () => {
@@ -97,14 +105,17 @@ describe('decodeSeriesData fallbacks for a truncated array', () => {
     expect(decoded.divisionId).toBe(0);
     expect(decoded.team1Id).toBe(0);
     expect(decoded.team2Id).toBe(0);
+    expect(decoded.seriesId).toBe(0);
   });
 });
 
 describe('legacy decimal decoder', () => {
   it('still reads ids minted before base36', () => {
     // Buttons live in Discord messages, so these keep arriving after a deploy.
-    expect(decodeLegacySeriesData(['123456789012345678', '7', '11', '22', 'Week 1'])).toEqual(
-      sample,
-    );
+    expect(decodeLegacySeriesData(['123456789012345678', '7', '11', '22', 'Week 1'])).toEqual({
+      ...sample,
+      // Predates the field; the series is resolved from the team pair instead.
+      seriesId: 0,
+    });
   });
 });

--- a/test/tournament.test.ts
+++ b/test/tournament.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createButtonData } from '../src/buttons/button.ts';
+import { createButtonData, parseButtonData } from '../src/buttons/button.ts';
 import { SeriesData } from '../src/types/toddData.ts';
 
 /**
@@ -104,11 +104,14 @@ const { handleBothTeamSubmission, handleTeamSelect } = await import('../src/comm
 
 const ORIGINAL_USER = '123456789012345678';
 
+// Unpinned, which is the state the selection flow is in: the series is not known
+// until handleBothTeamSubmission resolves it.
 const seriesData: SeriesData = {
   enemyCaptainId: '223456789012345678',
   divisionId: 7,
   team1Id: 11,
   team2Id: 22,
+  seriesId: 0,
   stage: 'REGULAR_SEASON',
 };
 
@@ -144,8 +147,11 @@ function makeInteraction(tag: string, data: SeriesData = seriesData, customId?: 
       calls.push('followUp');
       return {
         startThread: vi.fn(async () => ({
-          send: vi.fn(async (payload: { content?: string }) => {
+          // discord.js is not mocked, so these are real builders and toJSON()
+          // gives back the custom_id parseButtonData round-trips.
+          send: vi.fn(async (payload: { content?: string; components?: unknown[] }) => {
             threadSends.push(payload?.content ?? '');
+            if (payload?.components?.length) threadComponents.push(payload.components);
           }),
         })),
       };
@@ -172,6 +178,7 @@ function makeButtonInteraction(tag: string, data: SeriesData = seriesData) {
 
 let editReplyPayloads: unknown[] = [];
 let threadSends: string[] = [];
+let threadComponents: unknown[][] = [];
 
 /** First point the interaction is acknowledged, i.e. the 3s deadline stops mattering. */
 const ackIndex = () =>
@@ -195,6 +202,7 @@ beforeEach(() => {
   calls.length = 0;
   editReplyPayloads = [];
   threadSends = [];
+  threadComponents = [];
   seriesGames = [];
   issueRecoversLostGame = false;
 });
@@ -230,6 +238,44 @@ describe('handleBothTeamSubmission acknowledges before touching dennys', () => {
 
     expect(calls.indexOf('issueTournamentCode')).toBeLessThan(calls.indexOf('getSeries'));
     expect(threadSends.find(c => c.includes('# Game'))).toContain('# Game 2');
+  });
+});
+
+describe('the series is pinned once resolved', () => {
+  /** The row on the message that drives every later game. */
+  const generateButton = () => {
+    const row = threadComponents.at(-1)?.[0];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (row as any)?.toJSON().components[0];
+  };
+
+  it('resolves by team pair when nothing is pinned yet', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(calls).toContain('getSeriesId');
+  });
+
+  it('carries the resolved series on the button it posts', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    const parsed = parseButtonData(generateButton().custom_id);
+    expect(parsed.tag).toBe('generate_another');
+    expect(parsed.seriesData.seriesId).toBe(756);
+  });
+
+  it('does not resolve by team pair again once pinned', async () => {
+    // The failure this prevents: dennys closes series 1, and the next press
+    // silently starts issuing codes into series 2 for the same pair.
+    const interaction = makeInteraction('confirm', { ...seriesData, seriesId: 756 });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(calls).not.toContain('getSeriesId');
+    expect(calls).toContain('issueTournamentCode');
   });
 });
 


### PR DESCRIPTION
Closes #103. Stacked on #110 (issue #102) — review that first.

## Why

`SeriesData` carried no series, so every button press re-resolved one from the team pair. Two teams
can legitimately meet twice in a stage, and the moment Denny's closes the first, the next press
starts issuing codes into the second — the "game 4 instead of game 1" symptom.

Pinning also makes TC7 survivable: if Denny's closes a series wrongly, a live thread keeps working,
because `completed` only filters *fresh* lookups.

## The field goes before the stage, never after

The stage absorbs the remainder of the split — that is the only reason a stage containing a colon
round-trips — so anything appended past it breaks that.

Legacy ids carry one field fewer, so `parseButtonData` now picks the stage position by encoding
version:

```ts
const stageIndex = isVersioned ? 5 : 4;
const fields = [...metadata.slice(0, stageIndex), metadata.slice(stageIndex).join(':')];
```

Reading a legacy id at the new offset would have decoded its stage into `seriesId` and left the
stage empty. Legacy ids decode as `seriesId: 0`, which falls back to resolving by team pair exactly
as before — buttons live in Discord messages, not in Todd, and keep arriving after a redeploy.

## `getTournamentCode` takes an options object

It was seven positional params including a bare boolean, this made it eight, and the call sites read
as a row of unlabelled literals:

```ts
getTournamentCode(11, 22, 7, 'REGULAR_SEASON', interaction, '223…', true)
```

It also returns the resolved `seriesId` now, which is how `handleBothTeamSubmission` pins it onto
the button it posts.

## Budget

| | Worst case | Room for the stage |
|---|---|---|
| Before | 64 | 56 |
| **After** | **68** | **52** |

Still 32 characters spare. Both numbers are pinned by tests, so the next field can be judged against
a measurement rather than an estimate — and the headroom assertion written for exactly this change
stayed green without being touched.

## Two stale mocks fixed while here

`collectorFilters.test.ts` listed `createGame`, which no longer exists, and omitted three exports
`tournament.ts` imports. A bare-factory mock fails on first *access*, so it passed only because those
paths were never reached — a latent break for any later ticket. `ackBeforeSlowWork.test.ts` still
returned `gameId`, renamed to `tournamentCodeId` in 1.4.0.

## Acceptance

- [x] A thread whose series Denny's has since closed still issues codes into that same series (TC7)
- [x] Buttons minted before this change still decode, through the legacy path
- [x] Worst-case `custom_id` is measured and pinned in `test/button.test.ts`
- [x] No handler re-resolves by team pair once the id is pinned

## Verification

```
npm run typecheck   # src, then test/ via tsconfig.test.json — clean
npx vitest run      # Test Files 13 passed (13) / Tests 174 passed (174)
npx eslint .        # 18 problems (0 errors, 18 warnings) — all pre-existing
npm run build       # 5 commands emitted
```

Only test fixtures failed the first typecheck after the field was added — `src` was clean. That is
`tsconfig.test.json` from #101 doing its job.

The pinning test was confirmed to fail with the change reverted:

```
× does not resolve by team pair again once pinned
  → expected [ 'deferUpdate', 'getEvent', …(9) ] to not include 'getSeriesId'
```

`test/tournament.test.ts` also gains the component-assertion pattern this stack needs — discord.js
is unmocked, so real builders arrive in the stub and `row.toJSON().components[0].custom_id` feeds
straight back into `parseButtonData`.
