### PR TITLE
feat: Series picker for repeat series between the same teams

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -86,7 +86,30 @@ dispatches on the interaction type:
 
 Other string-select menus are **not** routed here. The series flow's dropdowns
 are handled by message component collectors attached to the message that created
-them (with a 5-minute window), not by the global router.
+them (with a 5-minute window), not by the global router. A new dropdown in that
+flow has to be added to the collector's filter list as well as to `TAG_CODES`,
+or it will never fire.
+
+### Choosing between repeat series
+
+Two teams can meet more than once inside a stage — a double round-robin, or a
+lower-bracket match and a grand-final rematch, both of which land under the same
+`EventStage`. Nothing on the series distinguishes them but the Bo count, and
+that is deliberate: two same-shape open series are interchangeable to a
+code-issuing service.
+
+`handleTeamSelect` resolves this once teams and stage are chosen, before
+anything exists in Dennys:
+
+| Open series for the pair | Behaviour |
+| --- | --- |
+| 0 | *"Failed to find a matching series for these teams."* |
+| 1 | used silently |
+| >1, same `totalGames` | lowest id, no prompt |
+| >1, different `totalGames` | a fourth dropdown labelled by Bo; Confirm is withheld until one is chosen |
+
+Changing a team or the stage clears a series already chosen against the old
+selection, so the prompt reappears rather than carrying a stale id forward.
 
 Every dispatch goes through `runGuarded(interaction, label, fn)`, which catches
 whatever the handler throws, distinguishes "the interaction is already dead" from
@@ -245,7 +268,7 @@ characters to 13; wire codes take the tag from 24 to 2.
 | Original | 100 | 20 |
 | Base36 ids | 86 | 34 |
 | ...plus tag codes | 64 | 56 |
-| ...plus `seriesId` | **68** | **52** |
+| ...plus `seriesId` | **68** | **50** |
 
 That still leaves 32 characters spare, so another id fits without revisiting
 this. `test/button.test.ts` pins both the boundary and the remaining headroom, so
@@ -257,7 +280,7 @@ the next field can be judged against a measurement rather than an estimate.
   that it absorbs the remainder of the split, so `Week 1: Opener` round-trips.
   The fields ahead of it are base36 or a tag, none of which can contain a `:`.
 - **The stage is still the field that can overflow.** Dennys returns
-  `eventStages` as free-form strings, so its length is not ours to control. 52
+  `eventStages` as free-form strings, so its length is not ours to control. 50
   characters fit. Past that, `seriesDataFits` refuses the series at stage
   selection — sized against the *longest* tag code, not the current one, because
   tags grow as a series advances (`s` is 1 character, `gc` is 2) and the late
@@ -308,10 +331,11 @@ The one function that talks to everything. Sequentially:
    chosen, falls back to its first stage.
 2. Rejects `team1 === team2` (*"This is not One For All"*).
 3. `getTeam(team1)`, `getTeam(team2)` — resolves display names.
-4. `getSeriesId(...)` — finds the scheduled series matching both teams and the
-   stage. **If no such series exists in Dennys, the flow stops here** with
-   *"Failed to find a matching series for these teams."* Todd never invents a
-   series; the schedule has to already be in the backend.
+4. `getSeriesId(...)` — only when the series is not already pinned, which is the
+   case for a series resolved before the picker existed. **If no such series
+   exists in Dennys, the flow stops here** with *"Failed to find a matching
+   series for these teams."* Todd never invents a series; the schedule has to
+   already be in the backend.
 5. `getSeries(seriesId)` — one lookup by id supplying both the Bo count
    (`totalGames`, which decides how many drafts to create) and the game number
    via `nextGameNumber`. These used to be two independent lookups by team pair,

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -181,6 +181,7 @@ generated the original code can generate another one."*
 | `team1_select` | Collector | Blue side |
 | `team2_select` | Collector | Red side |
 | `stage_select` | Collector | Stage within the division |
+| `series_select` | Collector | Which series, when the pair has more than one in the stage with different Bo counts. Not shown otherwise. |
 
 Only `select_event_group` goes through the global interaction router. The series
 menus are bound to collectors with a 5-minute lifetime and a filter that pins

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -233,7 +233,7 @@ Things to check:
   absorbs the rest of the split, so `Week 1: Opener` round-trips. Nothing ahead
   of it can contain a `:`.
 - **Exceeding 100 characters.** Discord's cap on `custom_id`. Base36 ids and tag
-  codes put the realistic worst case at 68, leaving 52 characters for the stage
+  codes put the realistic worst case at 68, leaving 50 characters for the stage
   name — the one field dennys hands us as a free-form string. Past that you get
   `CustomIdTooLongError` in the logs and *"The stage **X** has too long a name for
   Todd to track this series"* in Discord, raised at stage selection before

--- a/src/buttons/button.ts
+++ b/src/buttons/button.ts
@@ -37,6 +37,7 @@ const TAG_CODES: Record<string, string> = {
   team1_select: '1',
   team2_select: '2',
   stage_select: 's',
+  series_select: 'ss',
   confirm: 'c',
   switch: 'w',
   switch_sides: 'ws',
@@ -84,17 +85,24 @@ function serializeButtonData(tag: string, originalUserId: string, seriesData: Se
 }
 
 /**
+ * Sized against a series id well past anything dennys issues today, for the same
+ * reason the tag is sized against the longest code: the check runs while the
+ * series is still unresolved, and the id is pinned later, onto the button built
+ * after the code already exists.
+ */
+const WORST_CASE_SERIES_ID = 9999999;
+
+/**
  * True when this series still fits once it reaches the longest-tagged button in
  * the flow. Call it before doing anything irreversible - the stage name comes
  * from dennys as a free-form string, so it is the field that can push an
  * otherwise ordinary series over the cap.
  */
 export function seriesDataFits(originalUserId: string, seriesData: SeriesData): boolean {
-  const worstCase = serializeButtonData(
-    'x'.repeat(LONGEST_TAG_LENGTH),
-    originalUserId,
-    seriesData,
-  );
+  const worstCase = serializeButtonData('x'.repeat(LONGEST_TAG_LENGTH), originalUserId, {
+    ...seriesData,
+    seriesId: WORST_CASE_SERIES_ID,
+  });
   return worstCase.length <= MAX_CUSTOM_ID_LENGTH;
 }
 

--- a/src/commands/tournament.ts
+++ b/src/commands/tournament.ts
@@ -13,7 +13,7 @@ import { buildThreadName, getDraftLinksMarkdown } from '../util.ts';
 import { runGuarded, safeDefer, safeInteractionError } from '../interactionSafety.ts';
 import { User } from '../interfaces.ts';
 import { createButton, createButtonData, parseButtonData, seriesDataFits } from '../buttons/button.ts';
-import { getEvent, getEvents, getEventWithTeams, getSeries, getSeriesId, getTeam, issueTournamentCode, nextGameNumber, Team } from '../dennys.ts';
+import { findSeriesForTeams, getEvent, getEvents, getEventWithTeams, getSeries, getSeriesId, getTeam, issueTournamentCode, nextGameNumber, Team } from '../dennys.ts';
 import log from 'loglevel';
 import { SeriesData } from '../types/toddData.ts';
 
@@ -97,7 +97,7 @@ export async function handleDivisionSelect(
   const collector = message.createMessageComponentCollector({
     componentType: ComponentType.StringSelect,
     filter: (i: { user: User; customId: string }) =>
-      i.user.id === interaction.user.id && ['team1_select', 'team2_select', 'stage_select'].includes(parseButtonData(i.customId).tag),
+      i.user.id === interaction.user.id && ['team1_select', 'team2_select', 'stage_select', 'series_select'].includes(parseButtonData(i.customId).tag),
     time: 5 * 60 * 1000,
   });
 
@@ -124,6 +124,7 @@ export async function handleTeamSelect(
   let team1 = seriesData.team1Id;
   let team2 = seriesData.team2Id;
   let stage = seriesData.stage;
+  let pinnedSeriesId = seriesData.seriesId;
   const division = seriesData.divisionId;
   const tag = data.tag; 
   const enemyCaptainId = seriesData.enemyCaptainId;
@@ -133,6 +134,7 @@ export async function handleTeamSelect(
     team1 = '' as unknown as number;
     team2 = '' as unknown as number;
     stage = "";
+    pinnedSeriesId = 0;
   } else if (tag === 'switch') {
     logger.info("Switching sides");
     const temp = team1;
@@ -147,6 +149,13 @@ export async function handleTeamSelect(
     team2 = Number(values[0]);
   } else if (tag === 'stage_select') {
     stage = values[0] || "";
+  } else if (tag === 'series_select') {
+    pinnedSeriesId = Number(values[0]);
+  }
+
+  // Changing any of these invalidates a series chosen against the old ones.
+  if (tag === 'team1_select' || tag === 'team2_select' || tag === 'stage_select') {
+    pinnedSeriesId = 0;
   }
 
   // Ack before hitting dennys, otherwise a slow response expires the token.
@@ -168,7 +177,7 @@ export async function handleTeamSelect(
     team2Id: team2,
     divisionId: division,
     enemyCaptainId: enemyCaptainId,
-    seriesId: seriesData.seriesId,
+    seriesId: pinnedSeriesId,
     stage
   };
 
@@ -231,17 +240,65 @@ export async function handleTeamSelect(
 
   
 
-  const confirmButtonData = createButtonData('confirm', user.id, seriesDataUpdated);
+  // Two teams can meet more than once in a stage, and nothing on the series
+  // distinguishes them but the Bo. Resolve here rather than at confirm time, so
+  // the choice is made before anything exists in dennys.
+  const candidates = await findSeriesForTeams(Number(division), Number(team1), Number(team2), stage);
+  if (candidates.length === 0) {
+    await interaction.editReply({
+      content: 'Failed to find a matching series for these teams.',
+      components: [],
+    });
+    return;
+  }
+
+  // Same Bo means genuinely interchangeable to a code-issuing service, and a
+  // "Bo3 / Bo3" dropdown reads as broken. Lowest id keeps it deterministic.
+  const interchangeable = candidates.every(s => s.totalGames === candidates[0].totalGames);
+  const chosen =
+    candidates.find(s => s.id === pinnedSeriesId) ?? (interchangeable ? candidates[0] : null);
+
+  const summary =
+    `Blue Side: **${team1Name}**\n` + `Red Side: **${team2Name}**\n` + `Stage: **${stage}**`;
+
+  if (!chosen) {
+    const seriesDropdown = new StringSelectMenuBuilder()
+      .setCustomId(createButtonData('series_select', user.id, seriesDataUpdated).serialize())
+      .setPlaceholder('Select which series')
+      .addOptions(
+        candidates.map(s => ({
+          label: `Best of ${s.totalGames}`,
+          value: String(s.id),
+          default: s.id === pinnedSeriesId,
+        })),
+      );
+    await interaction.editReply({
+      content:
+        `${summary}\n\nThese teams have more than one series in this stage. ` +
+        `Pick the one you are playing.`,
+      components: [
+        row1,
+        row2,
+        row3,
+        new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(seriesDropdown),
+      ],
+    });
+    return;
+  }
+
+  const resolved: SeriesData = { ...seriesDataUpdated, seriesId: chosen.id };
+
+  const confirmButtonData = createButtonData('confirm', user.id, resolved);
   const confirm = createButton(confirmButtonData, 'Confirm', ButtonStyle.Success, '✅');
 
-  const switchSidesButtonData = createButtonData('switch', user.id, seriesDataUpdated);
+  const switchSidesButtonData = createButtonData('switch', user.id, resolved);
   const switchSides = createButton(
     switchSidesButtonData,
     'Switch Sides',
     ButtonStyle.Primary,
     '🔄',
   );
-  const cancelButtonData = createButtonData('cancel', user.id, seriesDataUpdated);
+  const cancelButtonData = createButtonData('cancel', user.id, resolved);
   const cancel = createButton(cancelButtonData, 'Cancel', ButtonStyle.Danger, '❌');
 
   const confirmRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
@@ -254,7 +311,8 @@ export async function handleTeamSelect(
     `Please confirm all looks right\n` +
     `# Blue Side: ${team1Name}\n` +
     `# Red Side: ${team2Name}\n` +
-    `# Stage: ${stage}`;
+    `# Stage: ${stage}\n` +
+    `# Best of ${chosen.totalGames}`;
   await interaction.editReply({
     content,
     components: [confirmRow],

--- a/src/dennys.ts
+++ b/src/dennys.ts
@@ -186,12 +186,20 @@ export const getTotalGames = async (
   return matchingSeries?.totalGames ?? 0;
 };
 
-const getSeriesForTeams = async (
+/**
+ * Every open series for this exact team pair and stage, lowest id first.
+ *
+ * More than one is legitimate: a double round-robin, or a lower-bracket match
+ * and a grand-final rematch, both of which land under the same `EventStage`.
+ * Sorted here so "pick the lowest id" is well defined without depending on the
+ * order dennys happens to return.
+ */
+export const findSeriesForTeams = async (
   eventId: number,
   team1: number,
   team2: number,
   stage: string,
-): Promise<Series | null> => {
+): Promise<Series[]> => {
   const query = new URLSearchParams();
   query.append('teamIds', String(team1));
   query.append('teamIds', String(team2));
@@ -201,27 +209,32 @@ const getSeriesForTeams = async (
   query.append('completed', 'false');
   const event = await apiGet(
     `/event/${eventId}/series?${query.toString()}`,
-    'getSeriesForTeams',
+    'findSeriesForTeams',
     eventWithSeriesSchema,
   );
-  for (const s of event.series) {
-    // Dennys filters on both query params server-side, so this is normally
-    // re-checking an already-correct single result. Defence in depth: a widened
-    // filter upstream would otherwise book a code against the wrong series.
-    if (
-      s.teamIds.includes(team1) &&
-      s.teamIds.includes(team2) &&
-      s.eventStage === stage
-    ) {
-      logger.info(
-        `Found matching series ${s.id} for teams ${team1}/${team2}, stage ${stage}, with totalGames: ${s.totalGames}`,
-      );
-      return s;
-    }
+  // Dennys filters on both query params server-side, so this is normally
+  // re-checking an already-correct result. Defence in depth: a widened filter
+  // upstream would otherwise book a code against the wrong series.
+  const matches = event.series
+    .filter(s => s.teamIds.includes(team1) && s.teamIds.includes(team2) && s.eventStage === stage)
+    .sort((a, b) => a.id - b.id);
+  if (matches.length === 0) {
+    logger.warn(`No matching series for teams ${team1}/${team2} in event ${eventId}, stage ${stage}`);
+  } else {
+    logger.info(
+      `Found ${matches.length} series for teams ${team1}/${team2}, stage ${stage}: ${matches.map(s => `${s.id} (Bo${s.totalGames})`).join(', ')}`,
+    );
   }
-  logger.warn(`No matching series for teams ${team1}/${team2} in event ${eventId}, stage ${stage}`);
-  return null;
+  return matches;
 };
+
+const getSeriesForTeams = async (
+  eventId: number,
+  team1: number,
+  team2: number,
+  stage: string,
+): Promise<Series | null> =>
+  (await findSeriesForTeams(eventId, team1, team2, stage))[0] ?? null;
 
 export const getSeriesId = async (
   eventId: number,

--- a/test/button.test.ts
+++ b/test/button.test.ts
@@ -117,14 +117,17 @@ describe("Discord's 100-character custom_id cap", () => {
     expect(() => data.serialize()).toThrow(CustomIdTooLongError);
   });
 
-  it('fits a stage name of 52 characters alongside everything else', () => {
+  it('fits a stage name of 50 characters alongside everything else', () => {
     // Dennys hands us eventStages as free-form strings, so this is the budget
-    // that actually matters. 'PROMOTION_RELEGATION' is 20.
+    // that actually matters. 'PROMOTION_RELEGATION' is 20. 50 rather than 52
+    // because seriesDataFits sizes against a series id larger than this fixture.
+    const stage = 'X'.repeat(50);
     const data = createButtonData('generate_another_confirm', '1234567890123456789', {
       ...worstCase,
-      stage: 'X'.repeat(52),
+      stage,
     });
     expect(data.serialize().length).toBeLessThanOrEqual(MAX_CUSTOM_ID_LENGTH);
+    expect(seriesDataFits('1234567890123456789', { ...worstCase, stage })).toBe(true);
   });
 });
 
@@ -133,19 +136,39 @@ describe('seriesDataFits', () => {
     expect(seriesDataFits('123456789012345678', seriesData)).toBe(true);
   });
 
+  it('is sized against a series id larger than the one being carried', () => {
+    // The check runs while the series is still unresolved, and the id is pinned
+    // later - onto the button built after the code already exists in dennys. A
+    // check sized against the current id would pass here and throw there.
+    const user = '1234567890123456789';
+    const unpinned: SeriesData = {
+      enemyCaptainId: user,
+      divisionId: 9999,
+      team1Id: 9999,
+      team2Id: 9999,
+      seriesId: 0,
+      stage: 'X'.repeat(51),
+    };
+    // Serializing it as it stands is fine; the check still refuses it.
+    expect(
+      createButtonData('generate_another_confirm', user, unpinned).serialize().length,
+    ).toBeLessThanOrEqual(MAX_CUSTOM_ID_LENGTH);
+    expect(seriesDataFits(user, unpinned)).toBe(false);
+  });
+
   it('rejects a stage name that would only overflow at a later, longer tag', () => {
     // Sized against the longest code on purpose: a stage can fit inside
     // 's' (stage_select) and still blow up inside 'gc'
     // (generate_another_confirm), which is built after the game exists.
     // Abbreviating the tags narrowed that window from 12 characters to 1, so
     // this pins the exact boundary rather than a comfortable margin.
-    const stage = 'X'.repeat(53);
+    const stage = 'X'.repeat(51);
     const user = '1234567890123456789';
     const worst = { ...seriesData, enemyCaptainId: user, divisionId: 9999, team1Id: 9999, team2Id: 9999, seriesId: 9999, stage };
     const short = createButtonData('stage_select', user, worst);
     expect(short.serialize().length).toBeLessThanOrEqual(MAX_CUSTOM_ID_LENGTH);
     expect(seriesDataFits(user, worst)).toBe(false);
-    expect(seriesDataFits(user, { ...worst, stage: 'X'.repeat(52) })).toBe(true);
+    expect(seriesDataFits(user, { ...worst, stage: 'X'.repeat(50) })).toBe(true);
   });
 });
 

--- a/test/tournament.test.ts
+++ b/test/tournament.test.ts
@@ -25,6 +25,19 @@ let seriesGames: { id: number; seriesId: number; number: number }[] = [];
  */
 let issueRecoversLostGame = false;
 
+/** One open series for the pair unless a test says otherwise. */
+const aSeries = (id: number, totalGames: number) => ({
+  id,
+  eventId: 7,
+  teamIds: [11, 22],
+  totalGames,
+  eventStage: 'REGULAR_SEASON',
+  completed: false,
+  completedAt: null,
+  reopenedAt: null,
+});
+let seriesCandidates: ReturnType<typeof aSeries>[] = [];
+
 vi.mock('../src/dennys.ts', async importOriginal => {
   // nextGameNumber is pure, so keep the real one - the game number a captain
   // sees is derived here and a stub would only be testing itself.
@@ -54,6 +67,10 @@ vi.mock('../src/dennys.ts', async importOriginal => {
     getSeriesId: vi.fn(async () => {
       calls.push('getSeriesId');
       return 756;
+    }),
+    findSeriesForTeams: vi.fn(async () => {
+      calls.push('findSeriesForTeams');
+      return seriesCandidates;
     }),
     issueTournamentCode: vi.fn(async () => {
       calls.push('issueTournamentCode');
@@ -205,6 +222,7 @@ beforeEach(() => {
   threadComponents = [];
   seriesGames = [];
   issueRecoversLostGame = false;
+  seriesCandidates = [aSeries(756, 3)];
 });
 
 describe('handleBothTeamSubmission acknowledges before touching dennys', () => {
@@ -238,6 +256,96 @@ describe('handleBothTeamSubmission acknowledges before touching dennys', () => {
 
     expect(calls.indexOf('issueTournamentCode')).toBeLessThan(calls.indexOf('getSeries'));
     expect(threadSends.find(c => c.includes('# Game'))).toContain('# Game 2');
+  });
+});
+
+describe('picking between repeat series for the same pair', () => {
+  /** Rows on the last thing rendered to the selection message. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rows = () => ((editReplyPayloads.at(-1) as any)?.components ?? []) as any[];
+  const rowTags = () =>
+    rows().map(r => parseButtonData(r.toJSON().components[0].custom_id).tag);
+
+  async function chooseAll(data: SeriesData = seriesData) {
+    const interaction = makeInteraction('stage_select', { ...data, stage: '' });
+    interaction.values = ['REGULAR_SEASON'];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleTeamSelect(interaction as any);
+    return interaction;
+  }
+
+  it('says so when the pair has no open series', async () => {
+    seriesCandidates = [];
+    await chooseAll();
+
+    expect(editReplyPayloads.at(-1)).toMatchObject({
+      content: expect.stringContaining('Failed to find a matching series'),
+      components: [],
+    });
+  });
+
+  it('uses the only candidate without asking', async () => {
+    await chooseAll();
+
+    expect(rowTags()).toEqual(['confirm']);
+    expect(editReplyPayloads.at(-1)).toMatchObject({
+      content: expect.stringContaining('Best of 3'),
+    });
+  });
+
+  it('asks which series when two differ by Bo', async () => {
+    seriesCandidates = [aSeries(756, 3), aSeries(801, 5)];
+    await chooseAll();
+
+    expect(rowTags()).toEqual([
+      'team1_select',
+      'team2_select',
+      'stage_select',
+      'series_select',
+    ]);
+    const options = rows()[3].toJSON().components[0].options;
+    expect(options.map((o: { label: string }) => o.label)).toEqual(['Best of 3', 'Best of 5']);
+  });
+
+  it('does not offer Confirm until a series is chosen', async () => {
+    seriesCandidates = [aSeries(756, 3), aSeries(801, 5)];
+    await chooseAll();
+
+    expect(rowTags()).not.toContain('confirm');
+  });
+
+  it('auto-picks the lowest id when two are the same Bo', async () => {
+    // Interchangeable to a code-issuing service, and a "Bo3 / Bo3" dropdown
+    // reads as broken.
+    seriesCandidates = [aSeries(801, 3), aSeries(756, 3)];
+    await chooseAll();
+
+    expect(rowTags()).toEqual(['confirm']);
+    const parsed = parseButtonData(rows()[0].toJSON().components[0].custom_id);
+    expect(parsed.seriesData.seriesId).toBe(801);
+  });
+
+  it('pins the chosen series onto Confirm', async () => {
+    seriesCandidates = [aSeries(756, 3), aSeries(801, 5)];
+    const interaction = makeInteraction('series_select', { ...seriesData, seriesId: 0 });
+    interaction.values = ['801'];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleTeamSelect(interaction as any);
+
+    expect(rowTags()).toEqual(['confirm']);
+    const parsed = parseButtonData(rows()[0].toJSON().components[0].custom_id);
+    expect(parsed.seriesData.seriesId).toBe(801);
+  });
+
+  it('drops a chosen series when the teams change under it', async () => {
+    seriesCandidates = [aSeries(756, 3), aSeries(801, 5)];
+    const interaction = makeInteraction('team1_select', { ...seriesData, seriesId: 801 });
+    interaction.values = ['11'];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleTeamSelect(interaction as any);
+
+    // Back to asking, rather than carrying a series chosen against the old pair.
+    expect(rowTags()).toContain('series_select');
   });
 });
 


### PR DESCRIPTION
Closes #104. Stacked on #111 (issue #103) — review that first.

## Why

Two teams can legitimately meet twice inside one stage — a double round-robin, or a lower-bracket
match and a grand-final rematch, since `EventStage` collapses every playoff round into one value.
With two candidates the lookup could not tell them apart, and Todd took whichever row came back
first.

There is deliberately no discriminator on the series and none coming: two same-shape open series are
genuinely interchangeable to a code-issuing service. The one case where they are not — a Bo3 and a
Bo5 both under `PLAYOFFS` — is distinguishable by `totalGames`, already on `SeriesDto`. No backend
change.

## Behaviour

| Open series for the pair | Behaviour |
|---|---|
| 0 | existing *"Failed to find a matching series for these teams."* |
| 1 | used silently, no extra click |
| >1, same `totalGames` | lowest id, no prompt |
| >1, different `totalGames` | a fourth dropdown labelled by Bo; **Confirm is withheld** until one is chosen |

Resolved in `handleTeamSelect`, before anything exists in Dennys, rather than at confirm time. Past
that point every button carries a series id that has to be right.

Changing a team or the stage **clears** a series chosen against the old selection, so the prompt
reappears rather than carrying a stale id into the code request.

## `findSeriesForTeams`

Returns every open series for the pair, **lowest id first**. Sorting here rather than relying on the
order Dennys happens to return is what makes "pick the lowest id" well defined. `getSeriesForTeams`
keeps its old first-match behaviour on top of it, so `getSeriesId` and `getTotalGames` are unchanged.

## A budget hole this exposed

`seriesDataFits` was sized against the series id being carried. But the check runs while the series
is still **unresolved**, and the id is pinned later — onto the button built after the code already
exists in Dennys. A 51-character stage passed the check with `seriesId: 0` and would then have thrown
`CustomIdTooLongError` at exactly the point the check exists to protect.

It is now sized against an id well past anything Dennys issues, the same trick already applied to the
tag (sized against the longest code, not the current one). That costs two characters of stage budget:

| | Room for the stage |
|---|---|
| Before this PR | 52 |
| **After** | **50** |

Pinned by a test that serializes fine and is still refused.

## Acceptance

- [x] Two series with differing `totalGames` → picker appears, selection is honoured, code and Bo come from the same series
- [x] Two series with the same `totalGames` → no picker, lowest id
- [x] One series → no picker, no extra click
- [x] Zero series → the existing error, unchanged
- [x] Confirm is not actionable until a series is resolved

## Verification

```
npm run typecheck   # clean
npx vitest run      # Test Files 13 passed (13) / Tests 182 passed (182)
npx eslint .        # 18 problems (0 errors, 18 warnings) — all pre-existing
npm run build       # ok
```

175 → 182. The picker tests were confirmed to fail with the branch removed:

```
× asks which series when two differ by Bo
× does not offer Confirm until a series is chosen
× drops a chosen series when the teams change under it
```

Note `series_select` had to be added to the collector's filter list as well as `TAG_CODES` — the
series dropdowns are not routed globally, so a menu missing from that list never fires.
