### PR TITLE
feat: In-thread series status from GET /series/{seriesId}

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -320,8 +320,38 @@ handleBothTeamSubmission  (tag: confirm)              │
   ├─ followUp: public "Division - Stage / Blue vs Red" message
   ├─ startThread(buildThreadName(...))
   ├─ thread.send: draft links + [Generate Next Game]
-  └─ thread.send: the game code block
+  ├─ thread.send: the game code block
+  └─ postSeriesControl: status + buttons, always last
 ```
+
+### The control message
+
+The thread is append-only, so the only way to keep the buttons reachable is to
+keep re-posting them last. `src/seriesControl.ts` does that:
+
+1. post the code message (content only);
+2. post the control message — status line plus the button row — and keep its id;
+3. only then scan the thread and delete every *other* control message.
+
+**The replacement is posted before the old one is removed.** Deleting first would
+leave the thread with no working buttons whenever the post then failed, stranding
+the captains. Two control messages for a moment is recoverable; none is not.
+
+Cleanup is best-effort and never fails the flow. Because the rule is "delete
+every control message except the newest", a skipped delete is corrected on the
+next post rather than accumulating — which is also what resolves the race when
+both captains generate at once and the loser's delete finds the message already
+gone (`10008`).
+
+**A control message is identified by `CONTROL_MARKER` at the start of its
+content**, never by "authored by the bot and carries components". Threads created
+before this existed carry the old Generate Next Game row on their *draft-links*
+message, and a components-only test would delete the draft links. Nothing else
+Todd posts may start with that marker.
+
+Code blocks and draft links are permanent. The control message is safe to delete
+precisely because everything on it is regenerated from `getSeries` on the next
+post.
 
 ### `getTournamentCode`
 

--- a/src/buttons/handlers/generateAnotherConfirm.ts
+++ b/src/buttons/handlers/generateAnotherConfirm.ts
@@ -1,8 +1,10 @@
-import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle } from "discord.js";
-import { createButton, createButtonData, parseButtonData } from "../button.ts";
+import { ButtonInteraction } from "discord.js";
+import { parseButtonData } from "../button.ts";
 import { getTournamentCode } from "../../commands/tournament.ts";
 import log from 'loglevel';
 import { safeDefer, safeInteractionError } from "../../interactionSafety.ts";
+import { buildControlRow, buildSeriesStatus, postSeriesControl } from "../../seriesControl.ts";
+import { SeriesData } from "../../types/toddData.ts";
 
 const logger =log.getLogger('generateAnotherConfirm');
 logger.setLevel('info');
@@ -56,15 +58,6 @@ export async function handleGenerateAnotherConfirm(interaction: ButtonInteractio
       return;
     }
 
-    // Create generate another button
-
-    // Regenerate button row
-    // data.metadata[3] = tournamentCode.gameId.toString(); 
-    // logger.info(data.metadata);
-    // const regenerateButtonData = createButtonData("regenerate_code", data.originalUserId, data.metadata);
-    // const regenerateButton = createButton(regenerateButtonData, "Code Not Work?", ButtonStyle.Secondary, '❓');
-
-
     // Drop the ephemeral "Generating..." message, then post the code publicly.
     await interaction.deleteReply();
 
@@ -80,6 +73,19 @@ export async function handleGenerateAnotherConfirm(interaction: ButtonInteractio
       flags: 1 << 2
     });
 
+    // Re-post the controls so they stay below the code that was just added.
+    const thread = interaction.channel;
+    if (thread && tournamentCode.series) {
+      const pinnedSeries: SeriesData = { ...seriesData, seriesId: tournamentCode.seriesId };
+      await postSeriesControl(
+        thread as unknown as Parameters<typeof postSeriesControl>[0],
+        buildSeriesStatus(tournamentCode.series, [
+          { id: seriesData.team1Id, name: tournamentCode.team1Name },
+          { id: seriesData.team2Id, name: tournamentCode.team2Name },
+        ]),
+        [buildControlRow(data.originalUserId, pinnedSeries)],
+      );
+    }
 
   } catch (error) {
     logger.error(error);

--- a/src/commands/tournament.ts
+++ b/src/commands/tournament.ts
@@ -13,6 +13,8 @@ import { buildThreadName, getDraftLinksMarkdown } from '../util.ts';
 import { runGuarded, safeDefer, safeInteractionError } from '../interactionSafety.ts';
 import { User } from '../interfaces.ts';
 import { createButton, createButtonData, parseButtonData, seriesDataFits } from '../buttons/button.ts';
+import { SeriesWithGames } from '../dennysSchemas.ts';
+import { buildControlRow, buildSeriesStatus, postSeriesControl } from '../seriesControl.ts';
 import { findSeriesForTeams, getEvent, getEvents, getEventWithTeams, getSeries, getSeriesId, getTeam, issueTournamentCode, nextGameNumber, Team } from '../dennys.ts';
 import log from 'loglevel';
 import { SeriesData } from '../types/toddData.ts';
@@ -373,20 +375,6 @@ export async function handleBothTeamSubmission(interaction: ButtonInteraction) {
       // Pinned here, at the one point the series is known: every later press
       // reads it back out rather than resolving from the team pair again.
       const pinnedSeries: SeriesData = { ...seriesData, seriesId: tournamentCode.seriesId };
-      const generateButtonData = createButtonData('generate_another', user.id, pinnedSeries);
-      const generateButton = createButton(
-        generateButtonData,
-        'Generate Next Game',
-        ButtonStyle.Success,
-        '⚔️',
-      );
-
-      // data.metadata[3] = tournamentCode.tournamentCodeId.toString();
-      // logger.info(data.metadata);
-      // const regenerateButtonData = createButtonData("regenerate_code", data.originalUserId, data.metadata);
-      // const regenerateButton = createButton(regenerateButtonData, "Code Not Work?", ButtonStyle.Secondary, '❓');
-
-      const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(generateButton);
       const discordResponse =
           `## ${tournamentCode.divisionName} - ${tournamentCode.stageName || 'UNKNOWN_STAGE'}\n` +
           `**__${tournamentCode.team1Name}__ v.s. __${tournamentCode.team2Name}__**\n\n` +
@@ -419,12 +407,24 @@ export async function handleBothTeamSubmission(interaction: ButtonInteraction) {
       await thread.send({
         content: links!,
         flags: 1 << 2,
-        components: [buttonRow],
       });
 
       await thread.send({
         content: tournamentCode.discordResponse?.toString() || "",
       });
+
+      // Controls go last and stay last, so the newest state is always at the
+      // bottom of the thread rather than scrolled away above the codes.
+      if (tournamentCode.series) {
+        await postSeriesControl(
+          thread,
+          buildSeriesStatus(tournamentCode.series, [
+            { id: seriesData.team1Id, name: tournamentCode.team1Name },
+            { id: seriesData.team2Id, name: tournamentCode.team2Name },
+          ]),
+          [buildControlRow(user.id, pinnedSeries)],
+        );
+      }
     }
   } catch (error) {
     logger.error('Failed to generate tournament code:', error);
@@ -477,6 +477,8 @@ export async function getTournamentCode({
   totalGames: number;
   /** The resolved series, for callers building buttons that must pin it. */
   seriesId: number;
+  /** The series as read after the code was issued, or null on an error path. */
+  series: SeriesWithGames | null;
 }> {
   //TODO: Call api with this informatio nand let it handle all this logic
   const division  = divisionId? Number(divisionId) : null
@@ -495,6 +497,7 @@ export async function getTournamentCode({
       team2Name: team2.toString(),
       tournamentCodeId: 0,
       seriesId: 0,
+      series: null,
       totalGames: 0,
     };
   }
@@ -510,6 +513,7 @@ export async function getTournamentCode({
       team2Name: team2.toString(),
       tournamentCodeId: 0,
       seriesId: 0,
+      series: null,
       totalGames:0
     };
   }
@@ -534,6 +538,7 @@ export async function getTournamentCode({
       team2Name,
       tournamentCodeId: 0,
       seriesId: 0,
+      series: null,
       totalGames: 0
     };
   }
@@ -575,6 +580,7 @@ export async function getTournamentCode({
     team2Name,
     tournamentCodeId: code.id,
     seriesId,
+    series,
     totalGames
   };
 }

--- a/src/seriesControl.ts
+++ b/src/seriesControl.ts
@@ -1,0 +1,143 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import { createButton, createButtonData } from './buttons/button.ts';
+import { SeriesData } from './types/toddData.ts';
+import { SeriesWithGames } from './dennys.ts';
+import log from 'loglevel';
+
+const logger = log.getLogger('seriesControl');
+logger.setLevel('info');
+
+/**
+ * First line of the control message, and the only way it is recognised.
+ *
+ * Matching on "has components" instead would also match the draft-links message
+ * in threads created before the control message existed, which carried the
+ * Generate Next Game row. Nothing else Todd posts may start with this.
+ */
+export const CONTROL_MARKER = '## 📋 Series status';
+
+/** Discord: the message is already gone, which the delete race below produces. */
+const UNKNOWN_MESSAGE = 10008;
+
+/** Threads are short; the control message is always among the most recent. */
+const SCAN_LIMIT = 50;
+
+/**
+ * How long a code may go unplayed before Todd stops assuming Riot is simply
+ * behind. Dennys pulls a played game from Riot whenever a code is issued, so
+ * anything sooner than this is very likely to arrive on its own.
+ */
+export const STALE_CODE_MS = 10 * 60 * 1000;
+
+type ControlMessage = {
+  id: string;
+  content: string;
+  components: readonly unknown[];
+  delete(): Promise<unknown>;
+};
+
+type ControlThread = {
+  send(payload: {
+    content: string;
+    components: ActionRowBuilder<ButtonBuilder>[];
+  }): Promise<{ id: string }>;
+  messages: { fetch(options: { limit: number }): Promise<Map<string, ControlMessage>> };
+};
+
+const isControlMessage = (message: ControlMessage) =>
+  message.content.startsWith(CONTROL_MARKER) && message.components.length > 0;
+
+const winsFor = (series: SeriesWithGames, teamId: number) =>
+  series.games.filter(game => game.result?.winningTeamId === teamId).length;
+
+/**
+ * True when the newest code has been outstanding long enough that waiting is no
+ * longer the better option. Codes issued and games played differing is the
+ * normal state between issuing a code and its result landing, so the elapsed
+ * time is the signal rather than the counts.
+ */
+export function isCodeStale(series: SeriesWithGames, now: number): boolean {
+  if (!series.lastCodeIssuedAt) return false;
+  const issued = Date.parse(series.lastCodeIssuedAt);
+  if (Number.isNaN(issued)) return false;
+  const played = series.lastGameAt ? Date.parse(series.lastGameAt) : 0;
+  if (played >= issued) return false;
+  return now - issued > STALE_CODE_MS;
+}
+
+export function buildSeriesStatus(
+  series: SeriesWithGames,
+  teams: { id: number; name: string }[],
+  now: number = Date.now(),
+): string {
+  const score = teams.map(team => `**${team.name}** ${winsFor(series, team.id)}`).join(' – ');
+  const lines = [`${score}  ·  Best of ${series.totalGames}`];
+
+  if (series.completed) {
+    lines.push('This series is complete.');
+  }
+
+  // One outstanding code is just the game in progress. More than one means codes
+  // were issued that nobody played - a replaced dead code, or both captains
+  // pressing at once. Only the code that was actually used needs a result.
+  const outstanding = series.tournamentCodes.length - series.games.length;
+  if (outstanding > 1) {
+    lines.push(`${outstanding} codes are outstanding — only the one you played needs reporting.`);
+  }
+
+  if (isCodeStale(series, now)) {
+    lines.push('The last code has no result yet.');
+  }
+
+  return lines.join('\n');
+}
+
+export function buildControlRow(
+  originalUserId: string,
+  seriesData: SeriesData,
+): ActionRowBuilder<ButtonBuilder> {
+  const generate = createButton(
+    createButtonData('generate_another', originalUserId, seriesData),
+    'Generate Next Game',
+    ButtonStyle.Success,
+    '⚔️',
+  );
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(generate);
+}
+
+/**
+ * Puts the control message at the bottom of the thread.
+ *
+ * The replacement is posted before the old ones are removed. Deleting first
+ * would leave the thread with no working buttons whenever the post then failed,
+ * and a captain with no way to continue; two control messages for a moment is
+ * recoverable, none is not.
+ *
+ * Cleanup is best-effort for the same reason. Since the rule is "delete every
+ * control message except the newest", a skipped delete is corrected on the next
+ * post rather than accumulating.
+ */
+export async function postSeriesControl(
+  thread: ControlThread,
+  content: string,
+  components: ActionRowBuilder<ButtonBuilder>[],
+): Promise<void> {
+  const posted = await thread.send({ content: `${CONTROL_MARKER}\n${content}`, components });
+
+  try {
+    const recent = await thread.messages.fetch({ limit: SCAN_LIMIT });
+    for (const message of recent.values()) {
+      if (message.id === posted.id || !isControlMessage(message)) continue;
+      try {
+        await message.delete();
+      } catch (error) {
+        const code = (error as { code?: number })?.code;
+        if (code !== UNKNOWN_MESSAGE) {
+          logger.warn(`Could not remove a previous series control message: ${String(error)}`);
+        }
+      }
+    }
+  } catch (error) {
+    logger.warn(`Could not scan the thread for previous control messages: ${String(error)}`);
+  }
+}

--- a/test/seriesControl.test.ts
+++ b/test/seriesControl.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ActionRowBuilder, ButtonBuilder } from 'discord.js';
+import {
+  CONTROL_MARKER,
+  STALE_CODE_MS,
+  buildControlRow,
+  buildSeriesStatus,
+  isCodeStale,
+  postSeriesControl,
+} from '../src/seriesControl.ts';
+import { parseButtonData } from '../src/buttons/button.ts';
+import { SeriesData } from '../src/types/toddData.ts';
+import { SeriesWithGames } from '../src/dennysSchemas.ts';
+
+const NOW = Date.parse('2026-08-09T12:00:00Z');
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+const TEAMS = [
+  { id: 11, name: 'Alpha' },
+  { id: 22, name: 'Bravo' },
+];
+
+const aSeries = (over: Partial<SeriesWithGames> = {}): SeriesWithGames => ({
+  id: 756,
+  eventId: 1,
+  teamIds: [11, 22],
+  totalGames: 3,
+  eventStage: 'REGULAR_SEASON',
+  completed: false,
+  completedAt: null,
+  reopenedAt: null,
+  tournamentCodes: [],
+  games: [],
+  lastCodeIssuedAt: null,
+  lastGameAt: null,
+  ...over,
+});
+
+const aGame = (number: number, winningTeamId: number) => ({
+  id: number,
+  seriesId: 756,
+  number,
+  result: { winningTeamId, losingTeamId: winningTeamId === 11 ? 22 : 11 },
+  tournamentCodeId: null,
+  riotMatchId: null,
+  createdAt: null,
+});
+
+const aCode = (id: number) => ({
+  id,
+  shortcode: `CODE${id}`,
+  seriesId: 756,
+  blueTeamId: 11,
+  redTeamId: 22,
+  createdAt: null,
+});
+
+const seriesData: SeriesData = {
+  enemyCaptainId: '223456789012345678',
+  divisionId: 7,
+  team1Id: 11,
+  team2Id: 22,
+  seriesId: 756,
+  stage: 'REGULAR_SEASON',
+};
+
+describe('buildSeriesStatus', () => {
+  it('reads 0 - 0 before anything is played', () => {
+    expect(buildSeriesStatus(aSeries(), TEAMS, NOW)).toContain('**Alpha** 0 – **Bravo** 0');
+  });
+
+  it('counts wins per team from the recorded results', () => {
+    const series = aSeries({ games: [aGame(1, 11), aGame(2, 22), aGame(3, 11)] });
+    expect(buildSeriesStatus(series, TEAMS, NOW)).toContain('**Alpha** 2 – **Bravo** 1');
+  });
+
+  it('names the Bo', () => {
+    expect(buildSeriesStatus(aSeries({ totalGames: 5 }), TEAMS, NOW)).toContain('Best of 5');
+  });
+
+  it('says when the series is complete', () => {
+    expect(buildSeriesStatus(aSeries({ completed: true }), TEAMS, NOW)).toContain(
+      'This series is complete',
+    );
+  });
+
+  it('does not treat a freshly issued code as an anomaly', () => {
+    // One code with no game is simply the game in progress. Warning here would
+    // fire on every single game.
+    const series = aSeries({
+      tournamentCodes: [aCode(1)],
+      lastCodeIssuedAt: ago(1000),
+    });
+    const status = buildSeriesStatus(series, TEAMS, NOW);
+    expect(status).not.toContain('outstanding');
+    expect(status).not.toContain('no result yet');
+  });
+
+  it('calls out more than one outstanding code', () => {
+    // Two captains pressing at once, or a dead code that was replaced. Only the
+    // one actually played needs a result.
+    const series = aSeries({ tournamentCodes: [aCode(1), aCode(2), aCode(3)] });
+    expect(buildSeriesStatus(series, TEAMS, NOW)).toContain('3 codes are outstanding');
+  });
+
+  it('calls out a code that has gone unanswered', () => {
+    const series = aSeries({
+      tournamentCodes: [aCode(1)],
+      lastCodeIssuedAt: ago(STALE_CODE_MS * 2),
+    });
+    expect(buildSeriesStatus(series, TEAMS, NOW)).toContain('no result yet');
+  });
+});
+
+describe('isCodeStale', () => {
+  it('is false when no code has been issued', () => {
+    expect(isCodeStale(aSeries(), NOW)).toBe(false);
+  });
+
+  it('is false inside the window', () => {
+    expect(isCodeStale(aSeries({ lastCodeIssuedAt: ago(STALE_CODE_MS - 1000) }), NOW)).toBe(false);
+  });
+
+  it('is true past it', () => {
+    expect(isCodeStale(aSeries({ lastCodeIssuedAt: ago(STALE_CODE_MS + 1000) }), NOW)).toBe(true);
+  });
+
+  it('is false once a game landed after the code', () => {
+    const series = aSeries({
+      lastCodeIssuedAt: ago(STALE_CODE_MS * 3),
+      lastGameAt: ago(STALE_CODE_MS * 2),
+    });
+    expect(isCodeStale(series, NOW)).toBe(false);
+  });
+});
+
+/**
+ * discord.js is not mocked, so rows reaching a stub are real builders. toJSON()
+ * types the button as a union that includes the SKU variant, which carries
+ * neither field, so it is narrowed to what a link-less button always has.
+ */
+export const buttonsOf = (row: ActionRowBuilder<ButtonBuilder>) =>
+  row.toJSON().components as unknown as { label: string; custom_id: string }[];
+
+describe('buildControlRow', () => {
+  it('carries the pinned series on Generate Next Game', () => {
+    const [button] = buttonsOf(buildControlRow('123456789012345678', seriesData));
+    expect(button.label).toBe('Generate Next Game');
+    const parsed = parseButtonData(button.custom_id);
+    expect(parsed.tag).toBe('generate_another');
+    expect(parsed.seriesData.seriesId).toBe(756);
+  });
+});
+
+type FakeMessage = {
+  id: string;
+  content: string;
+  components: unknown[];
+  delete: ReturnType<typeof vi.fn>;
+};
+
+function makeMessage(id: string, content: string, hasComponents: boolean): FakeMessage {
+  return {
+    id,
+    content,
+    components: hasComponents ? [{}] : [],
+    delete: vi.fn(async () => {}),
+  };
+}
+
+function makeThread(existing: FakeMessage[]) {
+  const sent: { content: string; components: ActionRowBuilder<ButtonBuilder>[] }[] = [];
+  let nextId = 100;
+  const thread = {
+    sent,
+    fetch: vi.fn(async () => new Map(existing.map(m => [m.id, m]))),
+    send: vi.fn(async (payload: { content: string; components: ActionRowBuilder<ButtonBuilder>[] }) => {
+      sent.push(payload);
+      return { id: String(nextId++) };
+    }),
+    get messages() {
+      return { fetch: thread.fetch };
+    },
+  };
+  return thread;
+}
+
+const row = () => buildControlRow('123456789012345678', seriesData);
+
+describe('postSeriesControl', () => {
+  let oldControl: FakeMessage;
+  let codeBlock: FakeMessage;
+  let legacyDraftLinks: FakeMessage;
+
+  beforeEach(() => {
+    oldControl = makeMessage('1', `${CONTROL_MARKER}\nolder status`, true);
+    codeBlock = makeMessage('2', '# Game 1\nCode: ```ABC123```', false);
+    // Threads created before the control message existed carry the Generate Next
+    // Game row on their draft-links message.
+    legacyDraftLinks = makeMessage('3', '[Blue Link](https://draft.test/1)', true);
+  });
+
+  it('posts the new control message behind the marker', async () => {
+    const thread = makeThread([]);
+    await postSeriesControl(thread, 'status here', [row()]);
+
+    expect(thread.sent).toHaveLength(1);
+    expect(thread.sent[0].content.startsWith(CONTROL_MARKER)).toBe(true);
+    expect(thread.sent[0].content).toContain('status here');
+  });
+
+  it('removes the previous control message', async () => {
+    const thread = makeThread([oldControl]);
+    await postSeriesControl(thread, 'status', [row()]);
+
+    expect(oldControl.delete).toHaveBeenCalled();
+  });
+
+  it('posts before it deletes, so a failed post leaves the old buttons live', async () => {
+    const thread = makeThread([oldControl]);
+    thread.send.mockRejectedValueOnce(new Error('discord is down'));
+
+    await expect(postSeriesControl(thread, 'status', [row()])).rejects.toThrow();
+    expect(oldControl.delete).not.toHaveBeenCalled();
+  });
+
+  it('leaves code blocks alone', async () => {
+    const thread = makeThread([oldControl, codeBlock]);
+    await postSeriesControl(thread, 'status', [row()]);
+
+    expect(codeBlock.delete).not.toHaveBeenCalled();
+  });
+
+  it('leaves a legacy draft-links message alone even though it has buttons', async () => {
+    const thread = makeThread([legacyDraftLinks]);
+    await postSeriesControl(thread, 'status', [row()]);
+
+    expect(legacyDraftLinks.delete).not.toHaveBeenCalled();
+  });
+
+  it('does not delete the message it just posted', async () => {
+    const thread = makeThread([]);
+    await postSeriesControl(thread, 'status', [row()]);
+    const posted = makeMessage('100', `${CONTROL_MARKER}\nstatus`, true);
+
+    const second = makeThread([posted]);
+    second.send.mockImplementationOnce(async (payload) => {
+      second.sent.push(payload);
+      return { id: '100' };
+    });
+    await postSeriesControl(second, 'status', [row()]);
+    expect(posted.delete).not.toHaveBeenCalled();
+  });
+
+  it('survives a delete that races another press', async () => {
+    // Both captains generating at once: the loser's delete finds it already gone.
+    const thread = makeThread([oldControl]);
+    oldControl.delete.mockRejectedValue({ code: 10008 });
+
+    await expect(postSeriesControl(thread, 'status', [row()])).resolves.toBeUndefined();
+  });
+
+  it('survives the thread scan failing entirely', async () => {
+    const thread = makeThread([oldControl]);
+    thread.fetch.mockRejectedValue(new Error('no permission'));
+
+    await expect(postSeriesControl(thread, 'status', [row()])).resolves.toBeUndefined();
+    expect(thread.sent).toHaveLength(1);
+  });
+});

--- a/test/tournament.test.ts
+++ b/test/tournament.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createButtonData, parseButtonData } from '../src/buttons/button.ts';
 import { SeriesData } from '../src/types/toddData.ts';
+import { CONTROL_MARKER } from '../src/seriesControl.ts';
 
 /**
  * tournament.ts owns the main flow, and the two things worth pinning are both
@@ -168,8 +169,11 @@ function makeInteraction(tag: string, data: SeriesData = seriesData, customId?: 
           // gives back the custom_id parseButtonData round-trips.
           send: vi.fn(async (payload: { content?: string; components?: unknown[] }) => {
             threadSends.push(payload?.content ?? '');
-            if (payload?.components?.length) threadComponents.push(payload.components);
+            threadComponents.push(payload?.components ?? []);
+            return { id: String(threadSends.length) };
           }),
+          // postSeriesControl scans for control messages it should replace.
+          messages: { fetch: vi.fn(async () => new Map()) },
         })),
       };
     }),
@@ -346,6 +350,38 @@ describe('picking between repeat series for the same pair', () => {
 
     // Back to asking, rather than carrying a series chosen against the old pair.
     expect(rowTags()).toContain('series_select');
+  });
+});
+
+describe('the thread ends with the controls', () => {
+  it('posts draft links, then the code, then the controls', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(threadSends[0]).toContain('draft links');
+    expect(threadSends[1]).toContain('# Game');
+    expect(threadSends.at(-1)).toContain(CONTROL_MARKER);
+  });
+
+  it('leaves the draft links and the code block without buttons', async () => {
+    // Only the control message carries them, so exactly one row is ever live.
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(threadComponents[0]).toEqual([]);
+    expect(threadComponents[1]).toEqual([]);
+    expect(threadComponents.at(-1)).toHaveLength(1);
+  });
+
+  it('renders the score and the Bo on the control message', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(threadSends.at(-1)).toContain('**Team 11** 0 – **Team 22** 0');
+    expect(threadSends.at(-1)).toContain('Best of 3');
   });
 });
 


### PR DESCRIPTION
Closes #105. Stacked on #113 (issue #104) — review that first.

## Scope grew, deliberately

The ticket said "a status line". It is **the control message**: one message, always last in the
thread, carrying the status *and* the whole button row. The durable `Generate Next Game` button
moves off the draft-links message onto it, so exactly one row is live at any moment instead of one
row per game accumulating down the thread.

The thread now reads: draft links → game 1 code → game 2 code → … → **[status + buttons]**.

## Post before delete

Threads are append-only and Discord cannot move a message, so staying at the bottom means
re-posting. The order matters:

1. post the code message (content only);
2. post the new control message, keep its id;
3. only **then** delete every *other* control message.

Deleting first would leave the thread with no working buttons whenever the post then failed —
captains stranded with no way to continue. Two control messages for a moment is recoverable; none is
not.

Step 3 is best-effort and never fails the flow. Because the rule is "delete all but the newest", a
skipped delete is corrected on the next post rather than accumulating — which is also what settles
the race when both captains generate at once and the loser's delete finds the message already gone
(`10008`).

## Only the control message is ever deleted

Recognised by `CONTROL_MARKER` at the start of its content, **never** by "authored by the bot and
carries components". Threads created before this carry the old `Generate Next Game` row on their
**draft-links** message — a components-only test would delete the draft links. Code blocks have no
components and were never at risk, but the marker is what makes the rule *"delete only the control
message"* rather than *"delete whatever has buttons"*.

Deleting is safe precisely because everything on the control message is regenerated from `getSeries`
on the next post.

## `codes > games` is not a warning

Every code spends time with no game against it — that is the gap between issuing and the result
landing. Rendering that as a warning would fire on every single game. What is worth saying:

| Condition | Shown |
|---|---|
| 1 outstanding code | nothing — that is the game in progress |
| >1 outstanding | *"N codes are outstanding — only the one you played needs reporting"* (TC8, TC4) |
| newest code older than the window with no newer game | *"The last code has no result yet"* |

`isCodeStale` is exported for #106's report gate to reuse, so the button and the status line cannot
disagree about what "stale" means.

## Acceptance

- [x] Score, Bo and completion state render from one `getSeries` call
- [x] The control message is always the last thing in the thread
- [x] A failed control post leaves the previous one intact and clickable
- [x] A failed delete does not fail the flow
- [x] Code blocks and legacy draft-links messages survive the scan
- [x] A freshly issued code does **not** read as an anomaly
- [x] A genuinely stale code is called out
- [x] A completed series says so
- [x] The status line never blocks or gates anything

## Verification

```
npm run typecheck   # clean
npx vitest run      # Test Files 14 passed (14) / Tests 205 passed (205)
npx eslint .        # 13 problems (0 errors, 13 warnings) — five fewer, dead imports removed
npm run build       # ok
```

182 → 205. Both safety properties were confirmed to fail when reverted:

```
× posts before it deletes, so a failed post leaves the old buttons live
× does not delete the message it just posted
× leaves a legacy draft-links message alone even though it has buttons
```

`getTournamentCode` now returns the series it already read, so neither caller fetches it twice.
