### PR TITLE
feat: Recovery paths for dead codes and Riot outages

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -375,6 +375,32 @@ A winner is mandatory; Dennys answers 422 to a report without one. The click is
 logged with the user id, because a captain can report a winner Riot does not
 corroborate and staff need the audit trail.
 
+### When Riot will not give out a code
+
+A code that generates but is dead, and a code that never generates, are different
+failures with the same consequence: the captains cannot play. Both reach the same
+two exits, because gating the custom path behind "Riot is down" strands anyone
+whose code technically works but is unusable.
+
+`isRiotGatewayError` separates this from a lookup failure, and
+`isRetryableRiotGatewayError` decides whether pressing again is worth offering:
+**503** is Riot unreachable, **502** is a refusal that a retry will not fix.
+
+**A failed code still opens the thread.** Without one, a series played entirely
+on customs has nowhere to live and nowhere to report from, so the public header
+and thread are posted anyway with the recovery buttons in place of a code.
+
+Replacing a dead code goes through the ordinary issue path rather than a separate
+one — a code nobody played produces no game, so reissuing does not advance the
+number, which makes a replacement the same operation as the next game.
+
+The custom path confirms before committing, since a custom costs the captains
+their stats, and the confirmation is where the scoreboard-screenshot reminder
+lives. Confirming posts a *We finished the custom game* button into the thread,
+tagged `report_result` so it rejoins the normal flow. That message is deliberately
+**not** a control message: the custom is played over the next half hour and the
+button has to survive however many codes are issued meanwhile.
+
 ### `getTournamentCode`
 
 The one function that talks to everything. Sequentially:

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -78,7 +78,9 @@ them get to drive the series buttons afterward.
 | *"No stages found for the selected division."* | The division has an empty `eventStages`. |
 | *"No teams found for the selected division."* | The division has no teams in Dennys. |
 | *"This is not One For All. No picking the same champs/teams"* | Blue and red are the same team. |
-| *"Failed to find a matching series for these teams."* | Dennys has no scheduled series for that pairing in that stage. The schedule must exist in the backend first. |
+| *"Failed to find a matching series for these teams."* | Dennys has no scheduled series for that pairing in that stage, or the only one is already complete — the lookup sends `completed=false`. |
+| *"Riot is not answering right now..."* | Riot returned 503. The thread is opened anyway with **Try again** and **Go play a custom game**. |
+| *"Riot refused to create a code for this game."* | Riot returned 502, which will not succeed on a retry, so only the custom path is offered. |
 | *"Error generating draft links! Please do so manually :)"* | The draft backend failed. **The tournament code was still created** — only the draft links are missing. |
 
 **Timeouts:** the dropdown collectors live for 5 minutes. After that the menus go
@@ -171,6 +173,9 @@ lookup table is [src/buttons/handlers.ts](../src/buttons/handlers.ts).
 | `report_result` | 📝 Report result | `handleReportResult` | Opens the winner picker. Only on the control message, and only once the newest code has gone unanswered. |
 | `report_team1_won` | 🟦 *<blue team>* won | `handleReportTeam1Won` | Records the winner and refreshes the thread. |
 | `report_team2_won` | 🟥 *<red team>* won | `handleReportTeam2Won` | As above, for the other team. |
+| `code_not_working` | ❓ Code not working? | `handleCodeNotWorking` | Offers a replacement code or the custom-game path. |
+| `play_custom` | ⚠️ Go play a custom game | `handlePlayCustom` | Confirms first: no stats, and take a scoreboard screenshot. |
+| `play_custom_confirm` | ✅ Yes, we're playing a custom | `handlePlayCustomConfirm` | Posts the *We finished the custom game* button into the thread. |
 | `end_series` | — | — | Retired. No button ever used it, and Dennys now closes a series automatically when enough results are written. The wire code stays reserved so a new tag cannot inherit it. |
 
 **Who is allowed to click:** every handler checks `interaction.user.id` against

--- a/src/buttons/button.ts
+++ b/src/buttons/button.ts
@@ -49,6 +49,9 @@ const TAG_CODES: Record<string, string> = {
   report_result: 'r',
   report_team1_won: 'r1',
   report_team2_won: 'r2',
+  code_not_working: 'cn',
+  play_custom: 'pc',
+  play_custom_confirm: 'pk',
   // Retired rather than removed, so a new tag cannot inherit the code. Dennys
   // closes a series on result write; nothing in Todd ends one.
   end_series: 'e',

--- a/src/buttons/handlers.ts
+++ b/src/buttons/handlers.ts
@@ -6,6 +6,7 @@ import log from 'loglevel';
 // import { handleRegenerateCode } from "./handlers/regenerateCode.ts";
 import { handleCancel } from "./handlers/cancelFlow.ts";
 import { handleReportResult, handleReportTeam1Won, handleReportTeam2Won } from "./handlers/reportResult.ts";
+import { handleCodeNotWorking, handlePlayCustom, handlePlayCustomConfirm } from "./handlers/recovery.ts";
 
 const logger =log.getLogger('handlers');
 logger.setLevel('info');
@@ -28,6 +29,12 @@ export function getButtonHandler(tag: string) {
       return handleReportTeam1Won;
     case 'report_team2_won':
       return handleReportTeam2Won;
+    case 'code_not_working':
+      return handleCodeNotWorking;
+    case 'play_custom':
+      return handlePlayCustom;
+    case 'play_custom_confirm':
+      return handlePlayCustomConfirm;
     case 'confirm':
       return handleBothTeamSubmission; // Assuming confirm is used for ending series
     case "switch":

--- a/src/buttons/handlers/recovery.ts
+++ b/src/buttons/handlers/recovery.ts
@@ -1,0 +1,142 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle } from 'discord.js';
+import { createButton, createButtonData, parseButtonData } from '../button.ts';
+import { safeDefer, safeInteractionError } from '../../interactionSafety.ts';
+import log from 'loglevel';
+
+const logger = log.getLogger('recovery');
+logger.setLevel('info');
+
+const mayAct = (interaction: ButtonInteraction, originalUserId: string, enemyCaptainId: string) =>
+  interaction.user.id === originalUserId || interaction.user.id === enemyCaptainId;
+
+async function refuse(interaction: ButtonInteraction) {
+  await interaction.reply({
+    content: 'Only the two captains in this series can do that.',
+    ephemeral: true,
+  });
+}
+
+/**
+ * A dead code and a code that never generated need the same exits. Gating the
+ * custom path on "Riot is down" strands captains whose code technically works
+ * but is unusable.
+ */
+export async function handleCodeNotWorking(interaction: ButtonInteraction) {
+  try {
+    const data = parseButtonData(interaction.customId);
+    const seriesData = data.seriesData;
+    if (!mayAct(interaction, data.originalUserId, seriesData.enemyCaptainId)) return refuse(interaction);
+    if (!(await safeDefer(interaction, { ephemeral: true }))) return;
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      createButton(
+        createButtonData('generate_another_confirm', data.originalUserId, seriesData),
+        'Generate a new one',
+        ButtonStyle.Primary,
+        '🔄',
+      ),
+      createButton(
+        createButtonData('play_custom', data.originalUserId, seriesData),
+        'Go play a custom game',
+        ButtonStyle.Secondary,
+        '⚠️',
+      ),
+      createButton(
+        createButtonData('cancel_flow', data.originalUserId, seriesData),
+        'Cancel',
+        ButtonStyle.Secondary,
+        '❌',
+      ),
+    );
+
+    await interaction.editReply({
+      content:
+        'A replacement code does not affect the game number — a code nobody played does not count.\n' +
+        'If Riot will not give you a working one, play a custom instead.',
+      components: [row],
+    });
+  } catch (error) {
+    logger.error(error);
+    await safeInteractionError(interaction, 'There was an error opening the recovery options.');
+  }
+}
+
+/** Confirms before committing, because a custom costs the captains their stats. */
+export async function handlePlayCustom(interaction: ButtonInteraction) {
+  try {
+    const data = parseButtonData(interaction.customId);
+    const seriesData = data.seriesData;
+    if (!mayAct(interaction, data.originalUserId, seriesData.enemyCaptainId)) return refuse(interaction);
+    if (!(await safeDefer(interaction, { ephemeral: true }))) return;
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      createButton(
+        createButtonData('play_custom_confirm', data.originalUserId, seriesData),
+        "Yes, we're playing a custom",
+        ButtonStyle.Danger,
+        '✅',
+      ),
+      createButton(
+        createButtonData('cancel_flow', data.originalUserId, seriesData),
+        'Cancel',
+        ButtonStyle.Secondary,
+        '❌',
+      ),
+    );
+
+    await interaction.editReply({
+      content:
+        'Are you sure? A custom game is not tracked by Riot, so there are **no stats** for it.\n' +
+        'Take a screenshot of the final scoreboard — you will need it for the post-game form.',
+      components: [row],
+    });
+  } catch (error) {
+    logger.error(error);
+    await safeInteractionError(interaction, 'There was an error opening the custom game prompt.');
+  }
+}
+
+/**
+ * Posts the way back into the normal flow. This message is not a control
+ * message and is never replaced: the custom is played over the next half hour,
+ * and the button has to survive however many codes are issued meanwhile.
+ */
+export async function handlePlayCustomConfirm(interaction: ButtonInteraction) {
+  try {
+    const data = parseButtonData(interaction.customId);
+    const seriesData = data.seriesData;
+    if (!mayAct(interaction, data.originalUserId, seriesData.enemyCaptainId)) return refuse(interaction);
+    if (!(await safeDefer(interaction, { update: true }))) return;
+
+    logger.info(
+      `Custom game started by ${interaction.user.id} for series ${seriesData.seriesId}`,
+    );
+
+    await interaction.editReply({
+      content: 'Play the custom, then use the button in the thread to report who won.',
+      components: [],
+    });
+
+    const thread = interaction.channel;
+    if (thread && 'send' in thread) {
+      await thread.send({
+        content:
+          '⚠️ A custom game is being played for this series. ' +
+          'Report the winner here once it is done — remember the scoreboard screenshot.',
+        components: [
+          new ActionRowBuilder<ButtonBuilder>().addComponents(
+            createButton(
+              createButtonData('report_result', data.originalUserId, seriesData),
+              'We finished the custom game',
+              ButtonStyle.Success,
+              '✅',
+            ),
+          ),
+        ],
+      });
+    }
+  } catch (error) {
+    logger.error(error);
+    await safeInteractionError(interaction, 'There was an error starting the custom game flow.');
+  }
+}

--- a/src/commands/tournament.ts
+++ b/src/commands/tournament.ts
@@ -8,6 +8,7 @@ import {
   SlashCommandBuilder,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
+  ThreadAutoArchiveDuration,
 } from 'discord.js';
 import { buildThreadName, getDraftLinksMarkdown } from '../util.ts';
 import { runGuarded, safeDefer, safeInteractionError } from '../interactionSafety.ts';
@@ -352,7 +353,15 @@ async function openSeriesThread(
   logger.info(`Creating thread: ${threadName}`);
   const thread = await publicMessage.startThread({
     name: threadName,
-    autoArchiveDuration: 60, // in minutes
+    // The longest Discord offers - one hour, one day, three days and one week
+    // are the only values it accepts, and archiving cannot be turned off.
+    //
+    // The timer runs from the last message rather than from creation, so an
+    // active series never archives on its own. This is for the gaps: an
+    // emergency pause can leave a thread quiet for hours, and it should still be
+    // in the channel's thread list when play resumes. Archiving is not a dead
+    // end either - an unlocked thread accepts a message and unarchives itself.
+    autoArchiveDuration: ThreadAutoArchiveDuration.OneWeek,
     reason: `Series thread for ${header.team1Name} vs ${header.team2Name}`,
   });
 

--- a/src/commands/tournament.ts
+++ b/src/commands/tournament.ts
@@ -14,8 +14,8 @@ import { runGuarded, safeDefer, safeInteractionError } from '../interactionSafet
 import { User } from '../interfaces.ts';
 import { createButton, createButtonData, parseButtonData, seriesDataFits } from '../buttons/button.ts';
 import { SeriesWithGames } from '../dennysSchemas.ts';
-import { buildControlRow, buildSeriesStatus, postSeriesControl } from '../seriesControl.ts';
-import { findSeriesForTeams, getEvent, getEvents, getEventWithTeams, getSeries, getSeriesId, getTeam, issueTournamentCode, nextGameNumber, Team } from '../dennys.ts';
+import { buildControlRow, buildRecoveryRow, buildSeriesStatus, postSeriesControl } from '../seriesControl.ts';
+import { findSeriesForTeams, getEvent, getEvents, getEventWithTeams, getSeries, getSeriesId, getTeam, isRetryableRiotGatewayError, isRiotGatewayError, issueTournamentCode, nextGameNumber, Team } from '../dennys.ts';
 import log from 'loglevel';
 import { SeriesData } from '../types/toddData.ts';
 
@@ -321,6 +321,45 @@ export async function handleTeamSelect(
   });
 }
 
+type SeriesHeader = Pick<
+  Awaited<ReturnType<typeof getTournamentCode>>,
+  'divisionName' | 'stageName' | 'team1Name' | 'team2Name' | 'shortcode'
+>;
+
+/**
+ * Posts the public series header and opens its thread, then puts `first` inside
+ * it. Reached from both the success path and the Riot-outage path: a series with
+ * no code still needs somewhere to live, or there is nowhere to report from.
+ */
+async function openSeriesThread(
+  interaction: ButtonInteraction,
+  userId: string,
+  header: SeriesHeader,
+  first: { content: string; components?: ActionRowBuilder<ButtonBuilder>[]; flags?: number },
+) {
+  const publicMessage = await interaction.followUp({
+    content:
+      `## ${header.divisionName} - ${header.stageName || 'UNKNOWN_STAGE'}\n` +
+      `**__${header.team1Name}__ v.s. __${header.team2Name}__**\n\n` +
+      `Series Created By: <@${userId}>`,
+    ephemeral: false,
+  });
+
+  const dateString = new Date().toISOString().split('T')[0];
+  // buildThreadName keeps us under Discord's 100 char cap; team names with
+  // special characters are already repaired upstream in dennys.ts.
+  const threadName = buildThreadName(header.team1Name, header.team2Name, dateString);
+  logger.info(`Creating thread: ${threadName}`);
+  const thread = await publicMessage.startThread({
+    name: threadName,
+    autoArchiveDuration: 60, // in minutes
+    reason: `Series thread for ${header.team1Name} vs ${header.team2Name}`,
+  });
+
+  await thread.send(first);
+  return thread;
+}
+
 export async function handleBothTeamSubmission(interaction: ButtonInteraction) {
   const { user } = interaction;
   const data = parseButtonData(interaction.customId);
@@ -358,7 +397,25 @@ export async function handleBothTeamSubmission(interaction: ButtonInteraction) {
       enemyCaptainId: seriesData.enemyCaptainId,
       first: true,
     });
-    if (tournamentCode.error != null) {
+    if (tournamentCode.riotUnavailable) {
+      // The series still gets a thread. A series played entirely on customs has
+      // to live somewhere, and without one there is nowhere to report from.
+      await interaction.editReply({
+        content: 'Riot would not issue a code. Continuing in a thread.',
+        components: [],
+      });
+      await interaction.deleteReply();
+      await openSeriesThread(interaction, user.id, tournamentCode, {
+        content: `${tournamentCode.error}`,
+        components: [
+          buildRecoveryRow(
+            user.id,
+            { ...seriesData, seriesId: tournamentCode.seriesId },
+            tournamentCode.retryable,
+          ),
+        ],
+      });
+    } else if (tournamentCode.error != null) {
       // Handle error: Update original interaction
       await interaction.editReply({
         content: tournamentCode.error,
@@ -375,36 +432,9 @@ export async function handleBothTeamSubmission(interaction: ButtonInteraction) {
       // Pinned here, at the one point the series is known: every later press
       // reads it back out rather than resolving from the team pair again.
       const pinnedSeries: SeriesData = { ...seriesData, seriesId: tournamentCode.seriesId };
-      const discordResponse =
-          `## ${tournamentCode.divisionName} - ${tournamentCode.stageName || 'UNKNOWN_STAGE'}\n` +
-          `**__${tournamentCode.team1Name}__ v.s. __${tournamentCode.team2Name}__**\n\n` +
-          `Series Created By: <@${user.id}>`;
-      const publicMessage = await interaction.followUp({
-        content: discordResponse,
-        ephemeral: false,
-      });
-
-      // Create a thread from the public message
-      const now = new Date();
-      const dateString = now.toISOString().split('T')[0];
-      // buildThreadName keeps us under Discord's 100 char cap; team names with
-      // special characters are already repaired upstream in dennys.ts.
-      const threadName = buildThreadName(
-        tournamentCode.team1Name,
-        tournamentCode.team2Name,
-        dateString,
-      );
-      logger.info(`Creating thread: ${threadName}`);
-      const thread = await publicMessage.startThread({
-        name: threadName,
-        autoArchiveDuration: 60, // in minutes
-        reason: `Draft links thread for tournament code ${tournamentCode.shortcode}`,
-      });
-
       const links = tournamentCode.draftLinks?.toString().concat("<@"+seriesData.enemyCaptainId+">") || null;
       logger.info(`Draft Links: ${links}`);
-      // Post the draft links in the thread
-      await thread.send({
+      const thread = await openSeriesThread(interaction, user.id, tournamentCode, {
         content: links!,
         flags: 1 << 2,
       });
@@ -479,6 +509,10 @@ export async function getTournamentCode({
   seriesId: number;
   /** The series as read after the code was issued, or null on an error path. */
   series: SeriesWithGames | null;
+  /** Riot, not us, refused the code. The custom-game path is the way forward. */
+  riotUnavailable: boolean;
+  /** Only meaningful with riotUnavailable: whether pressing again is worth it. */
+  retryable: boolean;
 }> {
   //TODO: Call api with this informatio nand let it handle all this logic
   const division  = divisionId? Number(divisionId) : null
@@ -498,6 +532,8 @@ export async function getTournamentCode({
       tournamentCodeId: 0,
       seriesId: 0,
       series: null,
+      riotUnavailable: false,
+      retryable: false,
       totalGames: 0,
     };
   }
@@ -514,6 +550,8 @@ export async function getTournamentCode({
       tournamentCodeId: 0,
       seriesId: 0,
       series: null,
+      riotUnavailable: false,
+      retryable: false,
       totalGames:0
     };
   }
@@ -539,11 +577,42 @@ export async function getTournamentCode({
       tournamentCodeId: 0,
       seriesId: 0,
       series: null,
+      riotUnavailable: false,
+      retryable: false,
       totalGames: 0
     };
   }
 
-  const code = await issueTournamentCode(seriesId, team1Data!, team2Data!);
+  let code;
+  try {
+    code = await issueTournamentCode(seriesId, team1Data!, team2Data!);
+  } catch (error) {
+    // Riot refusing is not a lookup failure, and telling a captain "no such
+    // series" when Riot is down leaves them with nothing to try.
+    if (!isRiotGatewayError(error)) throw error;
+    const retryable = isRetryableRiotGatewayError(error);
+    logger.error(`Riot could not issue a code for series ${seriesId}:`, error);
+    return {
+      discordResponse: null,
+      draftLinks: null,
+      shortcode: null,
+      gameNumber: 0,
+      error: retryable
+        ? 'Riot is not answering right now. Try again in a moment, or play a custom game.'
+        : 'Riot refused to create a code for this game. Playing a custom is the way forward.',
+      divisionId: division,
+      divisionName: divisionEvent?.name,
+      stageName: selectedStage,
+      team1Name,
+      team2Name,
+      tournamentCodeId: 0,
+      totalGames: 0,
+      seriesId,
+      series: null,
+      riotUnavailable: true,
+      retryable,
+    };
+  }
   const shortcode = code.shortcode;
 
   // Read the series *after* issuing, not before. Issuing a code makes dennys pull
@@ -581,6 +650,8 @@ export async function getTournamentCode({
     tournamentCodeId: code.id,
     seriesId,
     series,
+    riotUnavailable: false,
+    retryable: false,
     totalGames
   };
 }

--- a/src/seriesControl.ts
+++ b/src/seriesControl.ts
@@ -129,6 +129,47 @@ export function buildControlRow(
     );
   }
 
+  row.addComponents(
+    createButton(
+      createButtonData('code_not_working', originalUserId, seriesData),
+      'Code not working?',
+      ButtonStyle.Secondary,
+      '❓',
+    ),
+  );
+
+  return row;
+}
+
+/**
+ * Shown when Riot would not issue a code at all, so there is no code message to
+ * hang the usual controls on. The series still gets a thread: a series played
+ * entirely on customs has to live somewhere.
+ */
+export function buildRecoveryRow(
+  originalUserId: string,
+  seriesData: SeriesData,
+  retryable: boolean,
+): ActionRowBuilder<ButtonBuilder> {
+  const row = new ActionRowBuilder<ButtonBuilder>();
+  if (retryable) {
+    row.addComponents(
+      createButton(
+        createButtonData('generate_another_confirm', originalUserId, seriesData),
+        'Try again',
+        ButtonStyle.Primary,
+        '🔄',
+      ),
+    );
+  }
+  row.addComponents(
+    createButton(
+      createButtonData('play_custom', originalUserId, seriesData),
+      'Go play a custom game',
+      ButtonStyle.Secondary,
+      '⚠️',
+    ),
+  );
   return row;
 }
 

--- a/test/button.test.ts
+++ b/test/button.test.ts
@@ -46,6 +46,7 @@ describe('tag wire codes', () => {
     'confirm', 'switch', 'switch_sides', 'cancel', 'cancel_flow',
     'cancel_switch', 'generate_another', 'generate_another_confirm', 'end_series',
     'series_select', 'report_result', 'report_team1_won', 'report_team2_won',
+    'code_not_working', 'play_custom', 'play_custom_confirm',
   ];
 
   it('round-trips every tag back to the readable name handlers.ts switches on', () => {

--- a/test/handlers.test.ts
+++ b/test/handlers.test.ts
@@ -21,6 +21,9 @@ const ROUTED = [
   'report_result',
   'report_team1_won',
   'report_team2_won',
+  'code_not_working',
+  'play_custom',
+  'play_custom_confirm',
 ];
 
 describe('getButtonHandler', () => {

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SeriesData } from '../src/types/toddData.ts';
+import { createButtonData, parseButtonData } from '../src/buttons/button.ts';
+import { buildRecoveryRow } from '../src/seriesControl.ts';
+import {
+  handleCodeNotWorking,
+  handlePlayCustom,
+  handlePlayCustomConfirm,
+} from '../src/buttons/handlers/recovery.ts';
+
+/**
+ * A dead code and a code that never generated are different failures with the
+ * same consequence: the captains cannot play. Both have to reach the custom
+ * game, and the custom has to lead back into result reporting.
+ */
+
+const ORIGINAL_USER = '123456789012345678';
+const ENEMY_CAPTAIN = '223456789012345678';
+
+const seriesData: SeriesData = {
+  enemyCaptainId: ENEMY_CAPTAIN,
+  divisionId: 7,
+  team1Id: 11,
+  team2Id: 22,
+  seriesId: 756,
+  stage: 'REGULAR_SEASON',
+};
+
+const editReplyPayloads: { content?: string; components?: unknown[] }[] = [];
+const threadSends: { content?: string; components?: unknown[] }[] = [];
+
+function makeInteraction(tag: string, userId = ORIGINAL_USER) {
+  const interaction = {
+    customId: createButtonData(tag, ORIGINAL_USER, seriesData).serialize(),
+    user: { id: userId },
+    replied: false,
+    deferred: false,
+    isRepliable: () => true,
+    isMessageComponent: () => true,
+    channel: {
+      send: vi.fn(async (payload: { content?: string; components?: unknown[] }) => {
+        threadSends.push(payload);
+        return { id: '1' };
+      }),
+    },
+    deferUpdate: vi.fn(async () => {
+      interaction.deferred = true;
+    }),
+    deferReply: vi.fn(async () => {
+      interaction.deferred = true;
+    }),
+    editReply: vi.fn(async (payload: { content?: string; components?: unknown[] }) => {
+      editReplyPayloads.push(payload);
+    }),
+    reply: vi.fn(async (payload: { content?: string; components?: unknown[] }) => {
+      editReplyPayloads.push(payload);
+      interaction.replied = true;
+    }),
+  };
+  return interaction;
+}
+
+/** Narrows past the SKU variant of the button union, which carries no label. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const buttonsOf = (row: any) => row.toJSON().components as { label: string; custom_id: string }[];
+const labelsOf = (payload: { components?: unknown[] }) =>
+  buttonsOf((payload.components ?? [])[0]).map(b => b.label);
+const tagsOf = (payload: { components?: unknown[] }) =>
+  buttonsOf((payload.components ?? [])[0]).map(b => parseButtonData(b.custom_id).tag);
+
+beforeEach(() => {
+  editReplyPayloads.length = 0;
+  threadSends.length = 0;
+});
+
+describe('a code that will not generate', () => {
+  it('offers a retry only when pressing again could work', () => {
+    // 503 is Riot unreachable and worth another press; 502 is a hard refusal.
+    expect(labelsOf({ components: [buildRecoveryRow(ORIGINAL_USER, seriesData, true)] })).toEqual([
+      'Try again',
+      'Go play a custom game',
+    ]);
+    expect(labelsOf({ components: [buildRecoveryRow(ORIGINAL_USER, seriesData, false)] })).toEqual([
+      'Go play a custom game',
+    ]);
+  });
+
+  it('always reaches the custom path, retryable or not', () => {
+    for (const retryable of [true, false]) {
+      const tags = tagsOf({ components: [buildRecoveryRow(ORIGINAL_USER, seriesData, retryable)] });
+      expect(tags).toContain('play_custom');
+    }
+  });
+});
+
+describe('a code that generated but does not work', () => {
+  it('offers a replacement and the custom path', async () => {
+    const interaction = makeInteraction('code_not_working');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleCodeNotWorking(interaction as any);
+
+    expect(labelsOf(editReplyPayloads.at(-1)!)).toEqual([
+      'Generate a new one',
+      'Go play a custom game',
+      'Cancel',
+    ]);
+  });
+
+  it('replaces the code through the ordinary issue path, so the number holds', async () => {
+    // A code nobody played produces no game, so reissuing does not advance the
+    // number. That makes a replacement the same operation as the next game.
+    const interaction = makeInteraction('code_not_working');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleCodeNotWorking(interaction as any);
+
+    expect(tagsOf(editReplyPayloads.at(-1)!)[0]).toBe('generate_another_confirm');
+  });
+
+  it('carries the pinned series onto every option', async () => {
+    const interaction = makeInteraction('code_not_working');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleCodeNotWorking(interaction as any);
+
+    const ids = buttonsOf(editReplyPayloads.at(-1)!.components![0]).map(
+      b => parseButtonData(b.custom_id).seriesData.seriesId,
+    );
+    expect(ids).toEqual([756, 756, 756]);
+  });
+
+  it('refuses anyone but the two captains', async () => {
+    const interaction = makeInteraction('code_not_working', '999999999999999999');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleCodeNotWorking(interaction as any);
+
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+    expect(editReplyPayloads.at(-1)!.content).toContain('Only the two captains');
+  });
+});
+
+describe('committing to a custom game', () => {
+  it('warns about stats and the screenshot before committing', async () => {
+    const interaction = makeInteraction('play_custom');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handlePlayCustom(interaction as any);
+
+    const content = editReplyPayloads.at(-1)!.content!;
+    expect(content).toContain('no stats');
+    expect(content).toContain('screenshot');
+  });
+
+  it('makes it cancellable', async () => {
+    const interaction = makeInteraction('play_custom');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handlePlayCustom(interaction as any);
+
+    expect(tagsOf(editReplyPayloads.at(-1)!)).toEqual(['play_custom_confirm', 'cancel_flow']);
+  });
+
+  it('posts the way back into reporting once confirmed', async () => {
+    const interaction = makeInteraction('play_custom_confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handlePlayCustomConfirm(interaction as any);
+
+    expect(threadSends).toHaveLength(1);
+    expect(labelsOf(threadSends[0])).toEqual(['We finished the custom game']);
+    // Reuses the report flow rather than growing a second one.
+    expect(tagsOf(threadSends[0])).toEqual(['report_result']);
+  });
+
+  it('leaves that button in the thread rather than on a control message', async () => {
+    // The custom is played over the next half hour, and the button has to
+    // survive however many codes get issued meanwhile.
+    const interaction = makeInteraction('play_custom_confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handlePlayCustomConfirm(interaction as any);
+
+    expect(threadSends[0].content).not.toContain('Series status');
+  });
+
+  it('refuses anyone but the two captains', async () => {
+    const interaction = makeInteraction('play_custom_confirm', '999999999999999999');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handlePlayCustomConfirm(interaction as any);
+
+    expect(threadSends).toHaveLength(0);
+  });
+});

--- a/test/reportResult.test.ts
+++ b/test/reportResult.test.ts
@@ -130,7 +130,7 @@ describe('the Report button only appears once a code has gone unanswered', () =>
     const labels = buttonsOf(buildControlRow(ORIGINAL_USER, seriesData, series, now)).map(
       b => b.label,
     );
-    expect(labels).toEqual(['Generate Next Game']);
+    expect(labels).toEqual(['Generate Next Game', 'Code not working?']);
   });
 
   it('appears once the code is stale', () => {
@@ -138,7 +138,7 @@ describe('the Report button only appears once a code has gone unanswered', () =>
     const labels = buttonsOf(buildControlRow(ORIGINAL_USER, seriesData, series, now)).map(
       b => b.label,
     );
-    expect(labels).toEqual(['Generate Next Game', 'Report result']);
+    expect(labels).toEqual(['Generate Next Game', 'Report result', 'Code not working?']);
   });
 
   it('still appears on a completed series', () => {
@@ -149,6 +149,14 @@ describe('the Report button only appears once a code has gone unanswered', () =>
       b => b.label,
     );
     expect(labels).toContain('Report result');
+  });
+
+  it('always offers the recovery entry point, code or no code', () => {
+    // A dead code and a code that never generated need the same exits.
+    const labels = buttonsOf(buildControlRow(ORIGINAL_USER, seriesData, undefined, now)).map(
+      b => b.label,
+    );
+    expect(labels).toContain('Code not working?');
   });
 });
 

--- a/test/tournament.test.ts
+++ b/test/tournament.test.ts
@@ -169,17 +169,20 @@ function makeInteraction(tag: string, data: SeriesData = seriesData, customId?: 
     followUp: vi.fn(async () => {
       calls.push('followUp');
       return {
-        startThread: vi.fn(async () => ({
-          // discord.js is not mocked, so these are real builders and toJSON()
-          // gives back the custom_id parseButtonData round-trips.
-          send: vi.fn(async (payload: { content?: string; components?: unknown[] }) => {
-            threadSends.push(payload?.content ?? '');
-            threadComponents.push(payload?.components ?? []);
-            return { id: String(threadSends.length) };
-          }),
-          // postSeriesControl scans for control messages it should replace.
-          messages: { fetch: vi.fn(async () => new Map()) },
-        })),
+        startThread: vi.fn(async (options: { name: string; autoArchiveDuration: number }) => {
+          threadOptions.push(options);
+          return {
+            // discord.js is not mocked, so these are real builders and toJSON()
+            // gives back the custom_id parseButtonData round-trips.
+            send: vi.fn(async (payload: { content?: string; components?: unknown[] }) => {
+              threadSends.push(payload?.content ?? '');
+              threadComponents.push(payload?.components ?? []);
+              return { id: String(threadSends.length) };
+            }),
+            // postSeriesControl scans for control messages it should replace.
+            messages: { fetch: vi.fn(async () => new Map()) },
+          };
+        }),
       };
     }),
     deleteReply: vi.fn(async () => {
@@ -205,6 +208,7 @@ function makeButtonInteraction(tag: string, data: SeriesData = seriesData) {
 let editReplyPayloads: unknown[] = [];
 let threadSends: string[] = [];
 let threadComponents: unknown[][] = [];
+let threadOptions: { name: string; autoArchiveDuration: number }[] = [];
 
 /** First point the interaction is acknowledged, i.e. the 3s deadline stops mattering. */
 const ackIndex = () =>
@@ -229,6 +233,7 @@ beforeEach(() => {
   editReplyPayloads = [];
   threadSends = [];
   threadComponents = [];
+  threadOptions = [];
   seriesGames = [];
   issueRecoversLostGame = false;
   seriesCandidates = [aSeries(756, 3)];
@@ -416,6 +421,30 @@ describe('Riot refusing a code at game 1', () => {
 
     expect(threadSends[0]).toContain('Riot');
     expect(threadSends[0]).not.toContain('matching series');
+  });
+});
+
+describe('the series thread', () => {
+  it('is given the longest archive window Discord allows', async () => {
+    // A series can sit paused for hours and still take games afterwards, and
+    // Todd cannot post the next code into an archived thread. There is no way
+    // to opt out of archiving, so the ceiling is the closest thing to it.
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(threadOptions[0].autoArchiveDuration).toBe(10080);
+  });
+
+  it('gets the same window when Riot refused the code', async () => {
+    // That thread is the more important one: it is where a codeless series is
+    // played out, which takes longer than a normal one.
+    issueFailsWith = { status: 503 };
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(threadOptions[0].autoArchiveDuration).toBe(10080);
   });
 });
 

--- a/test/tournament.test.ts
+++ b/test/tournament.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createButtonData, parseButtonData } from '../src/buttons/button.ts';
 import { SeriesData } from '../src/types/toddData.ts';
 import { CONTROL_MARKER } from '../src/seriesControl.ts';
+import { HttpError } from '../src/http.ts';
 
 /**
  * tournament.ts owns the main flow, and the two things worth pinning are both
@@ -39,6 +40,9 @@ const aSeries = (id: number, totalGames: number) => ({
 });
 let seriesCandidates: ReturnType<typeof aSeries>[] = [];
 
+/** Set to make the code request fail the way Riot being down makes it fail. */
+let issueFailsWith: { status: number } | null = null;
+
 vi.mock('../src/dennys.ts', async importOriginal => {
   // nextGameNumber is pure, so keep the real one - the game number a captain
   // sees is derived here and a stub would only be testing itself.
@@ -75,6 +79,7 @@ vi.mock('../src/dennys.ts', async importOriginal => {
     }),
     issueTournamentCode: vi.fn(async () => {
       calls.push('issueTournamentCode');
+      if (issueFailsWith) throw new HttpError('riot', issueFailsWith.status, '');
       if (issueRecoversLostGame) seriesGames = [{ id: 4, seriesId: 756, number: 1 }];
       return {
         id: 9,
@@ -227,6 +232,7 @@ beforeEach(() => {
   seriesGames = [];
   issueRecoversLostGame = false;
   seriesCandidates = [aSeries(756, 3)];
+  issueFailsWith = null;
 });
 
 describe('handleBothTeamSubmission acknowledges before touching dennys', () => {
@@ -350,6 +356,66 @@ describe('picking between repeat series for the same pair', () => {
 
     // Back to asking, rather than carrying a series chosen against the old pair.
     expect(rowTags()).toContain('series_select');
+  });
+});
+
+describe('Riot refusing a code at game 1', () => {
+  beforeEach(() => {
+    issueFailsWith = { status: 503 };
+  });
+
+  it('still opens the thread, so a codeless series has somewhere to live', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(interaction.followUp).toHaveBeenCalled();
+    expect(threadSends).toHaveLength(1);
+  });
+
+  it('offers a retry and the custom path when Riot is merely unreachable', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const labels = (threadComponents[0][0] as any)
+      .toJSON()
+      .components.map((b: { label: string }) => b.label);
+    expect(labels).toEqual(['Try again', 'Go play a custom game']);
+  });
+
+  it('drops the retry when Riot refused outright', async () => {
+    // 502 will not succeed on another press; offering one wastes their time.
+    issueFailsWith = { status: 502 };
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const labels = (threadComponents[0][0] as any)
+      .toJSON()
+      .components.map((b: { label: string }) => b.label);
+    expect(labels).toEqual(['Go play a custom game']);
+  });
+
+  it('pins the resolved series onto the recovery buttons', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [button] = (threadComponents[0][0] as any).toJSON().components;
+    expect(parseButtonData(button.custom_id).seriesData.seriesId).toBe(756);
+  });
+
+  it('says Riot is the reason, not the series lookup', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(threadSends[0]).toContain('Riot');
+    expect(threadSends[0]).not.toContain('matching series');
   });
 });
 


### PR DESCRIPTION
Closes #107. Stacked on #115 (issue #106) — review that first. **Last in the #97 stack.**

## Why

A code that generates but is dead, and a code that never generates, are different failures with the
same consequence: the captains cannot play. Both produced *"An error occurred while generating the
tournament code"* and dead-ended.

`isRiotGatewayError` separates Riot refusing from a lookup failing, so a captain is no longer told
there is no such series when Riot is the problem. `isRetryableRiotGatewayError` decides whether a
retry is worth offering: **503** is Riot unreachable and worth another press, **502** is a refusal
that will not change.

## Both failures reach the same exits

```
[❓ Code not working?]  →  [🔄 Generate a new one] [⚠️ Go play a custom game] [❌ Cancel]
code issue fails 503   →  [🔄 Try again]          [⚠️ Go play a custom game]
code issue fails 502   →                          [⚠️ Go play a custom game]
```

Gating the custom path on "Riot is down" would strand anyone whose code technically works but is
unusable, so `Code not working?` sits on the control row unconditionally.

**Replacing a dead code goes through the ordinary issue path**, not a separate handler — a code
nobody played produces no game, so reissuing does not advance the number, which makes a replacement
the same operation as the next game.

## A failed code still opens the thread

This is the structural part. Without a thread, a series played entirely on customs has nowhere to
live and nowhere to report from — TC3 would be unreachable. So the public header and thread are
posted anyway, with the recovery buttons in place of a code. Header-and-thread creation is now shared
between that path and the ordinary one.

## The custom path

Confirms before committing, because a custom costs the captains their stats, and that is where the
screenshot reminder belongs:

> Are you sure? A custom game is not tracked by Riot, so there are **no stats** for it.
> Take a screenshot of the final scoreboard — you will need it for the post-game form.

Confirming posts **We finished the custom game** into the thread, tagged `report_result` so it
rejoins #106's flow rather than growing a second one. That message is deliberately **not** a control
message: the custom is played over the next half hour and the button has to survive however many
codes are issued meanwhile.

## Acceptance

- [x] A dead code can be replaced and the game number does not move (TC4)
- [x] Sides swapped after generation → regenerate, number stays correct (TC11)
- [x] Riot down → custom path → result reported → series advances (TC2)
- [x] Every code in a series failing still lets the series complete (TC3)
- [x] A failed regenerate answers ephemerally and offers the custom path
- [x] The custom confirmation states there are no stats **and** asks for a screenshot
- [x] 503 reads as "try again"; 502 does not
- [x] The custom path with no code ever issued leaves nothing outstanding for Riot to attribute later

## Verification

```
npm run typecheck   # clean
npx vitest run      # Test Files 16 passed (16) / Tests 239 passed (239)
npx eslint .        # 13 problems (0 errors, 13 warnings) — all pre-existing
npm run build       # ok
```

219 → 239. Both invariants were confirmed to fail when reverted:

```
× still opens the thread, so a codeless series has somewhere to live
× drops the retry when Riot refused outright
```

## The stack is now complete

`release/1.4.0` ← #109 ← #110 ← #111 ← #113 ← #114 ← #115 ← **this**. Nothing merges until #108
passes against Dennys staging, and `release/1.4.0` must not reach `main` until Dennys 1.4.0 does —
merging to `main` deploys to production, which still runs 1.3.1.
