### PR TITLE
fix: Gate "Code not working?" on an outstanding code

### DIFF
--- a/src/seriesControl.ts
+++ b/src/seriesControl.ts
@@ -50,6 +50,10 @@ const isControlMessage = (message: ControlMessage) =>
 const winsFor = (series: SeriesWithGames, teamId: number) =>
   series.games.filter(game => game.result?.winningTeamId === teamId).length;
 
+/** A code issued with no matching game yet - the only thing "Code not working?" can apply to. */
+const hasOutstandingCode = (series: SeriesWithGames) =>
+  series.tournamentCodes.length > series.games.length;
+
 /**
  * True when the newest code has been outstanding long enough that waiting is no
  * longer the better option. Codes issued and games played differing is the
@@ -129,14 +133,21 @@ export function buildControlRow(
     );
   }
 
-  row.addComponents(
-    createButton(
-      createButtonData('code_not_working', originalUserId, seriesData),
-      'Code not working?',
-      ButtonStyle.Secondary,
-      '❓',
-    ),
-  );
+  // Not gated on staleness like Report result is - staleness exists to give
+  // Riot's callback time to land, but a dead code can be known immediately
+  // (League client says "invalid code"), so this shouldn't wait on it. Gated
+  // on there being an outstanding code at all: once every issued code already
+  // has a matching reported game, there's nothing left for this to recover.
+  if (series && hasOutstandingCode(series)) {
+    row.addComponents(
+      createButton(
+        createButtonData('code_not_working', originalUserId, seriesData),
+        'Code not working?',
+        ButtonStyle.Secondary,
+        '❓',
+      ),
+    );
+  }
 
   return row;
 }

--- a/test/reportResult.test.ts
+++ b/test/reportResult.test.ts
@@ -30,6 +30,15 @@ const aSeries = (over: Record<string, unknown> = {}) => ({
   ...over,
 });
 
+const aCode = (id: number) => ({
+  id,
+  shortcode: `CODE${id}`,
+  seriesId: 756,
+  blueTeamId: 11,
+  redTeamId: 22,
+  createdAt: null,
+});
+
 vi.mock('../src/dennys.ts', async importOriginal => {
   const actual = await importOriginal<typeof import('../src/dennys.ts')>();
   return {
@@ -126,7 +135,7 @@ describe('the Report button only appears once a code has gone unanswered', () =>
   it('is absent while the code is fresh', () => {
     // A report filed now would be recorded codeless and duplicated when Riot
     // catches up, so waiting is the better default.
-    const series = aSeries({ lastCodeIssuedAt: ago(1000) });
+    const series = aSeries({ tournamentCodes: [aCode(1)], lastCodeIssuedAt: ago(1000) });
     const labels = buttonsOf(buildControlRow(ORIGINAL_USER, seriesData, series, now)).map(
       b => b.label,
     );
@@ -134,7 +143,10 @@ describe('the Report button only appears once a code has gone unanswered', () =>
   });
 
   it('appears once the code is stale', () => {
-    const series = aSeries({ lastCodeIssuedAt: ago(STALE_CODE_MS + 1000) });
+    const series = aSeries({
+      tournamentCodes: [aCode(1)],
+      lastCodeIssuedAt: ago(STALE_CODE_MS + 1000),
+    });
     const labels = buttonsOf(buildControlRow(ORIGINAL_USER, seriesData, series, now)).map(
       b => b.label,
     );
@@ -144,16 +156,31 @@ describe('the Report button only appears once a code has gone unanswered', () =>
   it('still appears on a completed series', () => {
     // Dennys does not block a completed series from taking results either, and a
     // captain correcting one that closed early must not be locked out.
-    const series = aSeries({ completed: true, lastCodeIssuedAt: ago(STALE_CODE_MS * 5) });
+    const series = aSeries({
+      completed: true,
+      tournamentCodes: [aCode(1)],
+      lastCodeIssuedAt: ago(STALE_CODE_MS * 5),
+    });
     const labels = buttonsOf(buildControlRow(ORIGINAL_USER, seriesData, series, now)).map(
       b => b.label,
     );
     expect(labels).toContain('Report result');
   });
 
-  it('always offers the recovery entry point, code or no code', () => {
-    // A dead code and a code that never generated need the same exits.
+  it('hides the recovery entry point once nothing is outstanding', () => {
+    // "Code not working?" only makes sense against a code that hasn't been
+    // reported yet. No series data at all means nothing to recover.
     const labels = buttonsOf(buildControlRow(ORIGINAL_USER, seriesData, undefined, now)).map(
+      b => b.label,
+    );
+    expect(labels).not.toContain('Code not working?');
+  });
+
+  it('offers the recovery entry point immediately for an outstanding code, without waiting for staleness', () => {
+    // A dead code can be known the moment it's tried - it shouldn't wait on
+    // the same window Report result does.
+    const series = aSeries({ tournamentCodes: [aCode(1)], lastCodeIssuedAt: ago(1000) });
+    const labels = buttonsOf(buildControlRow(ORIGINAL_USER, seriesData, series, now)).map(
       b => b.label,
     );
     expect(labels).toContain('Code not working?');

--- a/test/seriesControl.test.ts
+++ b/test/seriesControl.test.ts
@@ -150,6 +150,24 @@ describe('buildControlRow', () => {
     expect(parsed.tag).toBe('generate_another');
     expect(parsed.seriesData.seriesId).toBe(756);
   });
+
+  it('hides "Code not working?" once every issued code already has a matching game', () => {
+    const series = aSeries({ tournamentCodes: [aCode(1)], games: [aGame(1, 11)] });
+    const labels = buttonsOf(buildControlRow('123456789012345678', seriesData, series, NOW)).map(
+      b => b.label,
+    );
+    expect(labels).not.toContain('Code not working?');
+  });
+
+  it('shows "Code not working?" as soon as a code is outstanding, without waiting for staleness', () => {
+    const series = aSeries({ tournamentCodes: [aCode(1)], lastCodeIssuedAt: ago(1000) });
+    const labels = buttonsOf(buildControlRow('123456789012345678', seriesData, series, NOW)).map(
+      b => b.label,
+    );
+    expect(labels).toContain('Code not working?');
+    // Report result stays gated on staleness - only this button's gating changed.
+    expect(labels).not.toContain('Report result');
+  });
 });
 
 type FakeMessage = {


### PR DESCRIPTION
Closes #117. Stacked on #116 (issue #107) — review that first.

### Why

`buildControlRow` added "Code not working?" to the control row unconditionally. `Report result` is correctly gated on `isCodeStale`, but this button was not gated on anything — it kept showing once every issued code already had a matching reported game, with nothing left for it to apply to. "Generate a new one" just duplicated Generate Next Game, and "Go play a custom game" did not correspond to any stuck code.

Gated on there being an outstanding code (`tournamentCodes.length > games.length`) instead, and deliberately not on staleness like Report result is. Staleness exists to give Riot's callback time to land before offering a manual report; a dead code can be known the moment it is tried, so recovery should not wait on that same window.

### Two fixtures were asserting the bug

`reportResult.test.ts` had two `aSeries()` fixtures that set `lastCodeIssuedAt` without ever listing that code in `tournamentCodes` — the old unconditional button never noticed the gap. A third test asserted the old behaviour outright: *"always offers the recovery entry point, code or no code."* Fixed the fixtures and flipped that test to assert the button is hidden with no series data at all.

### Acceptance

- `Code not working?` is hidden once every issued code already has a matching reported game
- `Code not working?` appears immediately once a code is outstanding, without waiting for staleness
- `Report result` visibility is unchanged (still gated on `isCodeStale`)
- `Generate Next Game` visibility is unchanged (always shown)

### Verification

```
npm run typecheck   # clean
npx vitest run      # Test Files 16 passed (16) / Tests 247 passed (247)
npx eslint .        # 13 problems (0 errors, 13 warnings) — all pre-existing
npm run build       # ok
```

244 → 247, the three new ones split across `test/seriesControl.test.ts` and `test/reportResult.test.ts`