### PR TITLE
fix: Point at the custom game plainly on the recovery menu

### DIFF
--- a/src/buttons/handlers/recovery.ts
+++ b/src/buttons/handlers/recovery.ts
@@ -73,8 +73,8 @@ export async function handleCodeNotWorking(interaction: ButtonInteraction) {
 
     await interaction.editReply({
       content:
-        'A replacement code does not affect the game number — a code nobody played does not count.\n' +
-        'If Riot will not give you a working one, play a custom instead.',
+        'You may either regenerate a new code to use OR play a custom.\n' +
+        'If regenerating a code fails for any reason, please use a custom game.',
       components: [row],
     });
   } catch (error) {
@@ -90,8 +90,7 @@ export async function handlePlayCustom(interaction: ButtonInteraction) {
     const seriesData = data.seriesData;
     if (!mayAct(interaction, data.originalUserId, seriesData.enemyCaptainId)) return refuse(interaction);
     // Editing in place on the ephemeral menu is what stops the previous step
-    // ("A replacement code does not affect the game number...") from being
-    // left behind - see cameFromEphemeralMessage above.
+    // from being left behind - see cameFromEphemeralMessage above.
     const opts = cameFromEphemeralMessage(interaction) ? { update: true } : { ephemeral: true };
     if (!(await safeDefer(interaction, opts))) return;
 

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -151,6 +151,17 @@ describe('a code that generated but does not work', () => {
     ]);
   });
 
+  it('points at the custom game as the way out', async () => {
+    const interaction = makeInteraction('code_not_working');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleCodeNotWorking(interaction as any);
+
+    expect(editReplyPayloads.at(-1)!.content).toBe(
+      'You may either regenerate a new code to use OR play a custom.\n' +
+        'If regenerating a code fails for any reason, please use a custom game.',
+    );
+  });
+
   it('replaces the code through the ordinary issue path, so the number holds', async () => {
     // A code nobody played produces no game, so reissuing does not advance the
     // number. That makes a replacement the same operation as the next game -
@@ -218,8 +229,7 @@ describe('committing to a custom game', () => {
 
   it('edits the "Code not working?" menu in place rather than leaving it behind', async () => {
     // Previously this deferred a brand new ephemeral reply, so the prior step
-    // ("A replacement code does not affect the game number...") stayed on
-    // screen forever with dead buttons once the flow moved on.
+    // stayed on screen forever with dead buttons once the flow moved on.
     const interaction = makeInteraction('play_custom', ORIGINAL_USER, { ephemeralOrigin: true });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await handlePlayCustom(interaction as any);


### PR DESCRIPTION
### Why

The "Code not working?" menu opened with an explanation of game numbering before it got to what the captain could actually do:

> A replacement code does not affect the game number — a code nobody played does not count.
> If Riot will not give you a working one, play a custom instead.

A captain reaches that menu because a code will not work. The first line answers a question they did not ask, and it says nothing about the case that actually strands people — the replacement code failing too.

### Solution

> You may either regenerate a new code to use OR play a custom.
> If regenerating a code fails for any reason, please use a custom game.

Names both exits, and says which one to fall back to when the replacement fails as well. The buttons and their behaviour are unchanged.

### Acceptance Criteria

- The "Code not working?" menu shows both options and the fallback instruction
- Generate a new one / Go play a custom game / Cancel are unchanged
- Editing the menu in place on the way to the custom confirmation still works

### Verification

`360 passed`. One new test pins the exact text, and two comments quoting the removed sentence were updated so they no longer describe copy that doesn't exist. Clean `tsc --noEmit`; eslint 0 errors.