### PR TITLE
feat: Handle the 409 when a game has spent its code allowance

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -570,7 +570,7 @@ second code, and a result naming no code records a second game.
 
 Failures worth telling apart, all on the code issue: **502** is Riot refusing,
 **503** is Riot unreachable, and **409** is Dennys refusing because the game has
-used its three-code allowance (1.4.1). Error bodies are `{ code, message }`. See
+used its two-code allowance (1.4.1). Error bodies are `{ code, message }`. See
 [When Riot will not give out a code](#when-riot-will-not-give-out-a-code) and
 [When Dennys will not issue another code](#when-dennys-will-not-issue-another-code).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -401,6 +401,51 @@ tagged `report_result` so it rejoins the normal flow. That message is deliberate
 **not** a control message: the custom is played over the next half hour and the
 button has to survive however many codes are issued meanwhile.
 
+### When Dennys will not issue another code
+
+Dennys 1.4.1 caps tournament codes at **two per game, counted since the most
+recent recorded game**, and answers `409` with `{ code, message }` past that. The
+cap exists because nothing else stops a series burning Riot codes: a code that is
+never played leaves no game behind, so a captain pressing Generate could go round
+forever.
+
+`isCodeLimitError` classifies it and `dennysErrorMessage` pulls the message out
+of the body. **The message is shown verbatim** — it names the series and the
+count, which is more use than anything Todd could write in its place — with
+Todd's own line appended for what to do next. `dennysErrorMessage` returns null
+for a body that is not that shape, leaving the caller on its own wording.
+
+Two things follow from the cap only lifting when a result is written:
+
+- **Never retried, and no Try again button.** Unlike a 503 there is no moment at
+  which the same press starts working, so `buildCodeLimitRow` offers only the two
+  things that clear it: **Report Game N**, which credits a result to the code
+  still outstanding (`outstandingCodeId`), and **Go play a custom game**, which
+  rejoins the ordinary custom flow. The row is posted with `RECOVERY_MARKER`, so
+  the first result to land retires both buttons.
+- **A refusal at game 1 still opens the thread**, for the same reason a Riot
+  outage does: the series has to be played out somewhere.
+
+Todd counts the allowance itself so it can warn *before* the last code is spent.
+`remainingCodeAllowance` counts codes whose `createdAt` is after `lastGameAt` —
+the same rule Dennys applies — against `TOURNAMENT_CODE_LIMIT`. The status line
+says so at one remaining, which under a two-code cap is every game with a code
+out and reads as *your next code is the last one*, and at zero, where it also
+greys out Generate Next Game. It returns **null when the count cannot be worked
+out**, and null means say nothing and leave the button live: the number gates a
+button, and a guess that reads low would lock captains out of a code they are
+owed. Dennys is still the authority, and the 409 path above is what catches the
+cases Todd's count misses.
+
+`TOURNAMENT_CODE_LIMIT` is Todd's copy of a server-side rule, so the two can
+drift. Setting it *below* what Dennys enforces is safe — the button greys out a
+code early and the 409 path never fires — but setting it above means the status
+line promises a code Dennys will refuse. Dennys's own message is always shown
+verbatim, so the captain reads the real count either way.
+
+That null is why `tournamentCode.createdAt` is wrapped in `advisory()` rather
+than being required — see [Validation at the boundary](#validation-at-the-boundary).
+
 ### `getTournamentCode`
 
 The one function that talks to everything. Sequentially:
@@ -496,7 +541,7 @@ been posted, leaving a series announced with no thread.
 
 ## The Dennys contract
 
-Everything Todd needs from the backend, against **Dennys 1.4.0**. All requests
+Everything Todd needs from the backend, against **Dennys 1.4.1**. All requests
 carry `Authorization: Bearer ${DENNYS_TOKEN}`. Calls live in `src/dennys.ts`,
 response shapes in `src/dennysSchemas.ts`.
 
@@ -522,6 +567,12 @@ Bodies: `{ blueTeamId, redTeamId }` for the code, `{ winnerTeamId?, loserTeamId?
 tournamentCodeId?, shortcode? }` for a result, `{ winnerTeamId?, loserTeamId? }`
 for a completion. **None of the writes are retried** — a replay would issue a
 second code, and a result naming no code records a second game.
+
+Failures worth telling apart, all on the code issue: **502** is Riot refusing,
+**503** is Riot unreachable, and **409** is Dennys refusing because the game has
+used its three-code allowance (1.4.1). Error bodies are `{ code, message }`. See
+[When Riot will not give out a code](#when-riot-will-not-give-out-a-code) and
+[When Dennys will not issue another code](#when-dennys-will-not-issue-another-code).
 
 A result naming a code is the exception, and Todd depends on it. Dennys returns
 the game it already holds for that code with a 200 instead of inserting a second
@@ -584,6 +635,13 @@ mojibake repair so the validated strings are the repaired ones. Two rules:
 - **Everything else is wrapped in `unread()`** and degrades to null, so a change
   in a corner Todd ignores cannot take a flow down. Objects are non-strict, so
   unknown keys are stripped and an additive Dennys release is a no-op.
+
+`advisory()` is the deliberate exception to rule one, and currently has exactly
+one user: `TournamentCodeDto.createdAt`, which feeds the remaining-code count.
+Its consumer treats null as "unknown" and goes quiet, so a rename costs a line of
+status text — whereas requiring it would raise `DennysSchemaError` on the code
+issue itself and take the whole flow down over that line. Use it only where null
+is a genuinely usable answer; everything Todd depends on stays required.
 
 `DennysSchemaError` is deliberately separate from `HttpError`: the latter is
 Dennys working and saying no, the former needs a code change here.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -81,6 +81,7 @@ them get to drive the series buttons afterward.
 | *"Failed to find a matching series for these teams."* | Dennys has no scheduled series for that pairing in that stage, or the only one is already complete — the lookup sends `completed=false`. |
 | *"Riot is not answering right now..."* | Riot returned 503. The thread is opened anyway with **Try again** and **Go play a custom game**. |
 | *"Riot refused to create a code for this game."* | Riot returned 502, which will not succeed on a retry, so only the custom path is offered. |
+| *"Series 'N' has already been issued 2 tournament code(s)…"* | Dennys 409: this game has spent its code allowance. The message is Dennys's own, and the thread is opened anyway with **Report Game N** and **Go play a custom game**. No retry is offered — the allowance clears when a result is written. |
 | *"Error generating draft links! Please do so manually :)"* | The draft backend failed. **The tournament code was still created** — only the draft links are missing. |
 
 **Timeouts:** the dropdown collectors live for 5 minutes. After that the menus go

--- a/src/buttons/handlers/generateAnotherConfirm.ts
+++ b/src/buttons/handlers/generateAnotherConfirm.ts
@@ -4,6 +4,7 @@ import { getTournamentCode } from "../../commands/tournament.ts";
 import log from 'loglevel';
 import { safeDefer, safeInteractionError } from "../../interactionSafety.ts";
 import {
+  buildCodeLimitRow,
   buildControlRow,
   buildGameReportRow,
   buildRecoveryRow,
@@ -84,6 +85,31 @@ export async function handleGenerateAnotherConfirm(interaction: ButtonInteractio
           content: `${RECOVERY_MARKER} ${tournamentCode.error}`,
           components: [
             buildRecoveryRow(data.originalUserId, seriesData, tournamentCode.retryable),
+          ],
+        });
+      }
+      return;
+    }
+
+    // Dennys refused: this game has used its code allowance. The remedies go in
+    // the thread, where both captains can see them and either can act.
+    if (tournamentCode.codeLimitReached) {
+      await interaction.editReply({
+        content: tournamentCode.error!,
+        components: [],
+      });
+
+      const limitThread = interaction.channel;
+      if (limitThread && 'send' in limitThread) {
+        await limitThread.send({
+          content: `${RECOVERY_MARKER} ${tournamentCode.error}`,
+          components: [
+            buildCodeLimitRow(
+              data.originalUserId,
+              seriesData,
+              tournamentCode.tournamentCodeId || null,
+              tournamentCode.gameNumber,
+            ),
           ],
         });
       }

--- a/src/commands/tournament.ts
+++ b/src/commands/tournament.ts
@@ -16,6 +16,7 @@ import { User } from '../interfaces.ts';
 import { createButton, createButtonData, parseButtonData, seriesDataFits } from '../buttons/button.ts';
 import { SeriesWithGames } from '../dennysSchemas.ts';
 import {
+  buildCodeLimitRow,
   buildControlRow,
   buildGameReportRow,
   buildRecoveryRow,
@@ -24,7 +25,7 @@ import {
   postSeriesControl,
   RECOVERY_MARKER,
 } from '../seriesControl.ts';
-import { findSeriesForTeams, getEvent, getEvents, getEventWithTeams, getSeries, getSeriesId, getTeam, isRetryableRiotGatewayError, isRiotGatewayError, issueTournamentCode, nextGameNumber, Team } from '../dennys.ts';
+import { dennysErrorMessage, findSeriesForTeams, getEvent, getEvents, getEventWithTeams, getSeries, getSeriesId, getTeam, isCodeLimitError, isRetryableRiotGatewayError, isRiotGatewayError, issueTournamentCode, nextGameNumber, outstandingCodeId, Team } from '../dennys.ts';
 import log from 'loglevel';
 import { SeriesData } from '../types/toddData.ts';
 
@@ -414,22 +415,29 @@ export async function handleBothTeamSubmission(interaction: ButtonInteraction) {
       enemyCaptainId: seriesData.enemyCaptainId,
       first: true,
     });
-    if (tournamentCode.riotUnavailable) {
+    if (tournamentCode.riotUnavailable || tournamentCode.codeLimitReached) {
       // The series still gets a thread. A series played entirely on customs has
-      // to live somewhere, and without one there is nowhere to report from.
+      // to live somewhere, and without one there is nowhere to report from -
+      // which goes double for a series whose codes have run out.
       await interaction.editReply({
-        content: 'Riot would not issue a code. Continuing in a thread.',
+        content: tournamentCode.codeLimitReached
+          ? 'No more codes can be issued for this game. Continuing in a thread.'
+          : 'Riot would not issue a code. Continuing in a thread.',
         components: [],
       });
       await interaction.deleteReply();
+      const pinned: SeriesData = { ...seriesData, seriesId: tournamentCode.seriesId };
       await openSeriesThread(interaction, user.id, tournamentCode, {
         content: `${RECOVERY_MARKER} ${tournamentCode.error}`,
         components: [
-          buildRecoveryRow(
-            user.id,
-            { ...seriesData, seriesId: tournamentCode.seriesId },
-            tournamentCode.retryable,
-          ),
+          tournamentCode.codeLimitReached
+            ? buildCodeLimitRow(
+                user.id,
+                pinned,
+                tournamentCode.tournamentCodeId || null,
+                tournamentCode.gameNumber,
+              )
+            : buildRecoveryRow(user.id, pinned, tournamentCode.retryable),
         ],
       });
     } else if (tournamentCode.error != null) {
@@ -547,6 +555,8 @@ export async function getTournamentCode({
   riotUnavailable: boolean;
   /** Only meaningful with riotUnavailable: whether pressing again is worth it. */
   retryable: boolean;
+  /** Dennys refused: this game has used its code allowance. Never retryable. */
+  codeLimitReached: boolean;
 }> {
   //TODO: Call api with this informatio nand let it handle all this logic
   const division  = divisionId? Number(divisionId) : null
@@ -568,6 +578,7 @@ export async function getTournamentCode({
       series: null,
       riotUnavailable: false,
       retryable: false,
+      codeLimitReached: false,
       totalGames: 0,
     };
   }
@@ -586,6 +597,7 @@ export async function getTournamentCode({
       series: null,
       riotUnavailable: false,
       retryable: false,
+      codeLimitReached: false,
       totalGames:0
     };
   }
@@ -613,6 +625,7 @@ export async function getTournamentCode({
       series: null,
       riotUnavailable: false,
       retryable: false,
+      codeLimitReached: false,
       totalGames: 0
     };
   }
@@ -621,6 +634,42 @@ export async function getTournamentCode({
   try {
     code = await issueTournamentCode(seriesId, team1Data!, team2Data!);
   } catch (error) {
+    // Dennys caps codes per game since the last result. Never retried: the cap
+    // lifts on a result being written, so another press cannot clear it.
+    if (isCodeLimitError(error)) {
+      logger.warn(`Dennys refused a code for series ${seriesId}: the allowance for this game is spent`);
+      // A read, so failing it costs only the Report button on the row below.
+      const limited = await getSeries(seriesId).catch(() => null);
+      const postedSoFar = first
+        ? 0
+        : await highestPostedGameNumber(
+            interaction.channel as unknown as Parameters<typeof highestPostedGameNumber>[0],
+          );
+      return {
+        discordResponse: null,
+        draftLinks: null,
+        shortcode: null,
+        // The codes were all issued for the game in progress, so this is that
+        // game rather than the next one.
+        gameNumber: Math.max(1, limited ? nextGameNumber(limited) : 1, postedSoFar),
+        error:
+          `${dennysErrorMessage(error) ?? 'No more codes can be issued for this game.'}\n\n` +
+          'Another code will not help. Report the result of the game you already played, ' +
+          'or play a custom game and report the winner.',
+        divisionId: division,
+        divisionName: divisionEvent?.name,
+        stageName: selectedStage,
+        team1Name,
+        team2Name,
+        tournamentCodeId: (limited && outstandingCodeId(limited)) || 0,
+        totalGames: limited?.totalGames ?? 0,
+        seriesId,
+        series: limited,
+        riotUnavailable: false,
+        retryable: false,
+        codeLimitReached: true,
+      };
+    }
     // Riot refusing is not a lookup failure, and telling a captain "no such
     // series" when Riot is down leaves them with nothing to try.
     if (!isRiotGatewayError(error)) throw error;
@@ -645,6 +694,7 @@ export async function getTournamentCode({
       series: null,
       riotUnavailable: true,
       retryable,
+      codeLimitReached: false,
     };
   }
   const shortcode = code.shortcode;
@@ -701,6 +751,7 @@ export async function getTournamentCode({
     series,
     riotUnavailable: false,
     retryable: false,
+    codeLimitReached: false,
     totalGames
   };
 }

--- a/src/dennys.ts
+++ b/src/dennys.ts
@@ -316,6 +316,53 @@ export const completeSeries = async (
 export const reopenSeries = async (seriesId: number): Promise<Series> =>
   apiSend('DELETE', `/series/${seriesId}/complete`, `reopenSeries(${seriesId})`, seriesSchema);
 
+/** Codes allowed for one game before dennys refuses, counted since the last result. */
+export const TOURNAMENT_CODE_LIMIT = 2;
+
+/** The code allowance for this game is spent. 409 on POST /series/{id}/game means this. */
+export const isCodeLimitError = (error: unknown): error is HttpError =>
+  error instanceof HttpError && error.status === 409;
+
+/** What dennys said, from its `{ code, message }` error body. Null if it did not say. */
+export const dennysErrorMessage = (error: unknown): string | null => {
+  if (!(error instanceof HttpError) || !error.body) return null;
+  try {
+    const parsed = normalizeApiStrings(JSON.parse(error.body) as { message?: unknown });
+    const message = typeof parsed?.message === 'string' ? parsed.message.trim() : '';
+    if (!message) return null;
+    return message.length > 500 ? `${message.slice(0, 500)}…` : message;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Codes the game in progress may still take, or null when the series does not
+ * carry enough to tell. Unknown is reported as such: the number gates a button.
+ */
+export const remainingCodeAllowance = (series: SeriesWithGames): number | null => {
+  const since = series.lastGameAt ? Date.parse(series.lastGameAt) : 0;
+  if (Number.isNaN(since)) return null;
+  let issued = 0;
+  for (const code of series.tournamentCodes) {
+    if (!code.createdAt) return null;
+    const at = Date.parse(code.createdAt);
+    if (Number.isNaN(at)) return null;
+    if (at > since) issued++;
+  }
+  return Math.max(0, TOURNAMENT_CODE_LIMIT - issued);
+};
+
+/** The newest code no game has been recorded against - what a result would be for. */
+export const outstandingCodeId = (series: SeriesWithGames): number | null => {
+  const answered = new Set(
+    series.games.map(game => game.tournamentCodeId).filter((id): id is number => id != null),
+  );
+  return series.tournamentCodes
+    .filter(code => !answered.has(code.id))
+    .reduce<number | null>((newest, code) => (newest === null || code.id > newest ? code.id : newest), null);
+};
+
 /**
  * Code issue failed because of Riot rather than because of us: 502 is a hard
  * failure from Riot, 503 is Riot unreachable. Neither should read to a captain

--- a/src/dennysSchemas.ts
+++ b/src/dennysSchemas.ts
@@ -20,6 +20,9 @@ import { z } from 'zod';
  */
 const unread = <T extends z.ZodType>(schema: T) => schema.nullish().catch(null);
 
+/** Read, but null is a usable answer ("unknown"), so a rename must not fail the request. */
+const advisory = <T extends z.ZodType>(schema: T) => schema.nullish().catch(null);
+
 /**
  * A string whose known values are documented but not enforced.
  *
@@ -128,7 +131,8 @@ export const tournamentCodeSchema = z.object({
   seriesId: z.number(),
   blueTeamId: z.number(),
   redTeamId: z.number(),
-  createdAt: unread(z.string()),
+  // Counted against `lastGameAt` to work out the codes left for this game.
+  createdAt: advisory(z.string()),
 });
 
 export const gameResultSchema = z.object({

--- a/src/seriesControl.ts
+++ b/src/seriesControl.ts
@@ -1,7 +1,7 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
 import { createButton, createButtonData, parseButtonData } from './buttons/button.ts';
 import { SeriesData } from './types/toddData.ts';
-import { SeriesWithGames } from './dennys.ts';
+import { remainingCodeAllowance, SeriesWithGames, TOURNAMENT_CODE_LIMIT } from './dennys.ts';
 import log from 'loglevel';
 
 const logger = log.getLogger('seriesControl');
@@ -247,6 +247,18 @@ export function buildSeriesStatus(
     lines.push('The last code has no result yet.');
   }
 
+  // At zero this is why the button below is greyed. At one it is the warning
+  // that the next code is the last one - a two-code cap leaves no earlier point.
+  const remaining = remainingCodeAllowance(series);
+  if (remaining === 0) {
+    lines.push(
+      `No more codes can be issued for this game — ${TOURNAMENT_CODE_LIMIT} have already gone out. ` +
+        'Report a result, or play a custom game.',
+    );
+  } else if (remaining === 1) {
+    lines.push('One more code can be issued for this game.');
+  }
+
   return lines.join('\n');
 }
 
@@ -266,14 +278,18 @@ export function buildControlRow(
   seriesData: SeriesData,
   series?: SeriesWithGames,
 ): ActionRowBuilder<ButtonBuilder> {
-  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    createButton(
-      createButtonData('generate_another', originalUserId, seriesData),
-      'Generate Next Game',
-      ButtonStyle.Success,
-      '⚔️',
-    ),
+  const generate = createButton(
+    createButtonData('generate_another', originalUserId, seriesData),
+    'Generate Next Game',
+    ButtonStyle.Success,
+    '⚔️',
   );
+
+  // Greyed rather than dropped, and only on a known zero - an unknown allowance
+  // leaves it live and lets dennys be the one to refuse.
+  if (series && remainingCodeAllowance(series) === 0) generate.setDisabled(true);
+
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(generate);
 
   // Not gated on staleness - staleness exists to give Riot's callback time to
   // land, but a dead code can be known immediately (League client says "invalid
@@ -383,6 +399,43 @@ export function buildRecoveryRow(
         'Try again',
         ButtonStyle.Primary,
         '🔄',
+      ),
+    );
+  }
+  row.addComponents(
+    createButton(
+      createButtonData('play_custom', originalUserId, seriesData),
+      'Go play a custom game',
+      ButtonStyle.Secondary,
+      '⚠️',
+    ),
+  );
+  return row;
+}
+
+/**
+ * Shown when dennys refuses a code because this game has spent its allowance.
+ * Both buttons clear it; no retry, because pressing again cannot.
+ */
+export function buildCodeLimitRow(
+  originalUserId: string,
+  seriesData: SeriesData,
+  outstandingCodeId: number | null,
+  gameNumber: number,
+): ActionRowBuilder<ButtonBuilder> {
+  const row = new ActionRowBuilder<ButtonBuilder>();
+  if (outstandingCodeId != null) {
+    row.addComponents(
+      createButton(
+        createButtonData(
+          'report_result',
+          originalUserId,
+          seriesData,
+          encodeReportTarget(outstandingCodeId, gameNumber),
+        ),
+        `Report Game ${gameNumber}`,
+        ButtonStyle.Primary,
+        '📝',
       ),
     );
   }

--- a/test/dennys.test.ts
+++ b/test/dennys.test.ts
@@ -33,9 +33,14 @@ const {
   reopenSeries,
   isRiotGatewayError,
   isRetryableRiotGatewayError,
+  isCodeLimitError,
+  dennysErrorMessage,
+  remainingCodeAllowance,
+  outstandingCodeId,
   DennysSchemaError,
 } = await import('../src/dennys.ts');
 const { HttpError } = await import('../src/http.ts');
+const { seriesWithGamesSchema } = await import('../src/dennysSchemas.ts');
 
 const API_URL = 'https://dennys.test'; // seeded by test/setup.ts
 const WHEN = '2026-08-09T00:00:00Z';
@@ -410,5 +415,105 @@ describe('riot gateway failures are distinguishable', () => {
   it('marks only 503 as worth another press', () => {
     expect(isRetryableRiotGatewayError(new HttpError('boom', 503, ''))).toBe(true);
     expect(isRetryableRiotGatewayError(new HttpError('boom', 502, ''))).toBe(false);
+  });
+});
+
+/**
+ * Dennys 1.4.1 caps codes per game, counted since the most recent recorded
+ * game, and answers 409 past that (todd-bot#126).
+ */
+describe('the tournament code allowance', () => {
+  const LIMIT_BODY = JSON.stringify({
+    code: 409,
+    message: "Series '756' has already been issued 2 tournament code(s).",
+  });
+
+  it('is not retried - the write policy already forbids it', async () => {
+    fetchWithRetry.mockResolvedValue(fail(409, LIMIT_BODY));
+    await expect(issueTournamentCode(756, BLUE, RED)).rejects.toThrow(HttpError);
+    expect(optsOf().retries).toBe(0);
+    expect(fetchWithRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('classifies the 409 as a spent allowance, and nothing else as one', () => {
+    expect(isCodeLimitError(new HttpError('nope', 409, LIMIT_BODY))).toBe(true);
+    expect(isCodeLimitError(new HttpError('nope', 502, ''))).toBe(false);
+    expect(isCodeLimitError(new Error('network'))).toBe(false);
+  });
+
+  it("hands back dennys's own message, which names the series and the count", () => {
+    expect(dennysErrorMessage(new HttpError('nope', 409, LIMIT_BODY))).toBe(
+      "Series '756' has already been issued 2 tournament code(s).",
+    );
+  });
+
+  it('repairs mojibake in the message, like every other string from dennys', () => {
+    const body = JSON.stringify({ code: 409, message: mojibake('Série ’756’ is done') });
+    expect(dennysErrorMessage(new HttpError('nope', 409, body))).toBe('Série ’756’ is done');
+  });
+
+  it('says nothing when the body is not the shape dennys documents', () => {
+    expect(dennysErrorMessage(new HttpError('nope', 409, 'Gateway Timeout'))).toBeNull();
+    expect(dennysErrorMessage(new HttpError('nope', 409, '{"code":409}'))).toBeNull();
+    expect(dennysErrorMessage(new HttpError('nope', 409, ''))).toBeNull();
+    expect(dennysErrorMessage(new Error('network'))).toBeNull();
+  });
+
+  it('trims a message too long to sit in a Discord reply', () => {
+    const body = JSON.stringify({ code: 409, message: 'x'.repeat(900) });
+    expect(dennysErrorMessage(new HttpError('nope', 409, body))!.length).toBe(501);
+  });
+
+  it('counts the allowance from the codes issued since the last recorded game', () => {
+    const series = seriesWithGamesSchema.parse(
+      aSeriesWithGames({
+        tournamentCodes: [
+          aCode({ id: 1, createdAt: '2026-08-09T10:00:00Z' }),
+          aCode({ id: 2, createdAt: '2026-08-09T12:00:00Z' }),
+        ],
+        games: [aGame({ tournamentCodeId: 1 })],
+        lastGameAt: '2026-08-09T11:00:00Z',
+      }),
+    );
+    expect(remainingCodeAllowance(series)).toBe(1);
+  });
+
+  it('counts every code when no game has been recorded yet', () => {
+    const series = seriesWithGamesSchema.parse(
+      aSeriesWithGames({
+        tournamentCodes: [
+          aCode({ id: 1, createdAt: '2026-08-09T10:00:00Z' }),
+          aCode({ id: 2, createdAt: '2026-08-09T11:00:00Z' }),
+        ],
+      }),
+    );
+    expect(remainingCodeAllowance(series)).toBe(0);
+  });
+
+  it('reports the count as unknown rather than guessing it', () => {
+    const series = seriesWithGamesSchema.parse(
+      aSeriesWithGames({ tournamentCodes: [aCode({ createdAt: null })] }),
+    );
+    expect(remainingCodeAllowance(series)).toBeNull();
+  });
+
+  it('finds the newest code no game has been recorded against', () => {
+    const series = seriesWithGamesSchema.parse(
+      aSeriesWithGames({
+        tournamentCodes: [aCode({ id: 1 }), aCode({ id: 2 }), aCode({ id: 3 })],
+        games: [aGame({ tournamentCodeId: 3 })],
+      }),
+    );
+    expect(outstandingCodeId(series)).toBe(2);
+  });
+
+  it('has no code to report against once every one is answered', () => {
+    const series = seriesWithGamesSchema.parse(
+      aSeriesWithGames({
+        tournamentCodes: [aCode({ id: 1 })],
+        games: [aGame({ tournamentCodeId: 1 })],
+      }),
+    );
+    expect(outstandingCodeId(series)).toBeNull();
   });
 });

--- a/test/generateAnotherConfirm.test.ts
+++ b/test/generateAnotherConfirm.test.ts
@@ -225,6 +225,68 @@ describe('a regenerate that succeeds', () => {
   });
 });
 
+/**
+ * Dennys 1.4.1 answers 409 once a game has taken its codes (todd-bot#126).
+ * The clicking captain sees it on their ephemeral message, but the remedies go
+ * in the thread: either captain can report the game or start the custom.
+ */
+describe('a mid-series regenerate dennys refuses on the code allowance', () => {
+  const refused = {
+    error:
+      "Series '756' has already been issued 2 tournament code(s).\n\n" +
+      'Another code will not help. Report the result of the game you already played, ' +
+      'or play a custom game and report the winner.',
+    riotUnavailable: false,
+    retryable: false,
+    codeLimitReached: true,
+    discordResponse: null,
+    tournamentCodeId: 9,
+    gameNumber: 2,
+    series: null,
+    seriesId: 756,
+  };
+
+  it('posts the remedies to the thread, and no retry among them', async () => {
+    getTournamentCode.mockResolvedValue(refused);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleGenerateAnotherConfirm(makeInteraction() as any);
+
+    expect(threadSends).toHaveLength(1);
+    expect(labelsOf(threadSends[0])).toEqual(['Report Game 2', 'Go play a custom game']);
+    expect(tagsOf(threadSends[0])).toEqual(['report_result', 'play_custom']);
+  });
+
+  it("shows dennys's message rather than a generic failure", async () => {
+    getTournamentCode.mockResolvedValue(refused);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleGenerateAnotherConfirm(makeInteraction() as any);
+
+    expect(editReplyPayloads.at(-1)?.content).toContain('already been issued 2 tournament code(s)');
+    expect(threadSends[0].content).toContain('already been issued 2 tournament code(s)');
+  });
+
+  it('leaves the report button out when no code is outstanding', async () => {
+    getTournamentCode.mockResolvedValue({ ...refused, tournamentCodeId: 0 });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleGenerateAnotherConfirm(makeInteraction() as any);
+
+    expect(labelsOf(threadSends[0])).toEqual(['Go play a custom game']);
+  });
+
+  it('does not post a code message - there is no code', async () => {
+    getTournamentCode.mockResolvedValue(refused);
+    const interaction = makeInteraction();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleGenerateAnotherConfirm(interaction as any);
+
+    expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+});
+
 describe('a non-Riot error on regenerate', () => {
   it('does not post a recovery row - there is nothing to recover from', async () => {
     getTournamentCode.mockResolvedValue({

--- a/test/seriesControl.test.ts
+++ b/test/seriesControl.test.ts
@@ -5,6 +5,7 @@ import {
   CUSTOM_MARKER,
   RECOVERY_MARKER,
   STALE_CODE_MS,
+  buildCodeLimitRow,
   buildControlRow,
   buildGameReportRow,
   buildSeriesStatus,
@@ -59,13 +60,13 @@ const aGame = (number: number, winningTeamId: number, tournamentCodeId: number |
   createdAt: null,
 });
 
-const aCode = (id: number) => ({
+const aCode = (id: number, createdAt: string | null = null) => ({
   id,
   shortcode: `CODE${id}`,
   seriesId: 756,
   blueTeamId: 11,
   redTeamId: 22,
-  createdAt: null,
+  createdAt,
 });
 
 const seriesData: SeriesData = {
@@ -327,6 +328,108 @@ describe('buildControlRow', () => {
       b => b.label,
     );
     expect(labels).not.toContain('Report result');
+  });
+});
+
+/**
+ * Dennys 1.4.1 caps tournament codes per game, counted since the most recent
+ * recorded game (todd-bot#126). Todd counts the same way so it can say how many
+ * are left before a captain spends the last one.
+ */
+describe('the code allowance', () => {
+  const USER = '123456789012345678';
+  const spent = () =>
+    aSeries({
+      tournamentCodes: [aCode(1, ago(2000)), aCode(2, ago(1000))],
+      lastCodeIssuedAt: ago(1000),
+    });
+  const labelsOfControl = (series?: SeriesWithGames) =>
+    buttonsOf(buildControlRow(USER, seriesData, series)).map(b => b.label);
+  const generateIsDisabled = (series?: SeriesWithGames) =>
+    (buttonsOf(buildControlRow(USER, seriesData, series))[0] as { disabled?: boolean }).disabled ===
+    true;
+
+  it('says nothing before a code has gone out for this game', () => {
+    // Both codes belong to the game already in the books, so the game in
+    // progress has its full allowance.
+    const series = aSeries({
+      tournamentCodes: [aCode(1, ago(5000)), aCode(2, ago(4000))],
+      games: [aGame(1, 11, 2)],
+      lastGameAt: ago(3000),
+    });
+    const status = buildSeriesStatus(series, TEAMS, NOW);
+    expect(status).not.toContain('No more codes');
+    expect(status).not.toContain('One more code');
+  });
+
+  it('warns when one code is left', () => {
+    const series = aSeries({ tournamentCodes: [aCode(1, ago(1000))] });
+    expect(buildSeriesStatus(series, TEAMS, NOW)).toContain('One more code can be issued');
+  });
+
+  it('says why, and names the remedies, once the allowance is spent', () => {
+    const status = buildSeriesStatus(spent(), TEAMS, NOW);
+    expect(status).toContain('No more codes can be issued for this game');
+    expect(status).toContain('Report a result');
+    expect(status).toContain('custom game');
+  });
+
+  it('greys out Generate Next Game at zero rather than removing it', () => {
+    expect(labelsOfControl(spent())).toContain('Generate Next Game');
+    expect(generateIsDisabled(spent())).toBe(true);
+  });
+
+  it('counts only the codes issued since the last recorded game', () => {
+    // The first two belong to a game that is now in the books. Counting those
+    // would read as spent and grey the button out with a code still owed.
+    const series = aSeries({
+      tournamentCodes: [aCode(1, ago(5000)), aCode(2, ago(4000)), aCode(3, ago(1000))],
+      games: [aGame(1, 11, 2)],
+      lastGameAt: ago(3000),
+    });
+    expect(buildSeriesStatus(series, TEAMS, NOW)).not.toContain('No more codes');
+    expect(generateIsDisabled(series)).toBe(false);
+  });
+
+  it('stays quiet and leaves the button live when the count cannot be worked out', () => {
+    // A code with no createdAt makes the count a guess, and a guess that reads
+    // low locks captains out of a code they are owed. Dennys can refuse instead.
+    const series = aSeries({ tournamentCodes: [aCode(1), aCode(2)] });
+    expect(buildSeriesStatus(series, TEAMS, NOW)).not.toContain('No more codes');
+    expect(generateIsDisabled(series)).toBe(false);
+  });
+
+  it('leaves the button live when there is no series to read', () => {
+    expect(generateIsDisabled()).toBe(false);
+  });
+});
+
+describe('buildCodeLimitRow', () => {
+  const USER = '123456789012345678';
+
+  it('offers both remedies: report what was played, or play a custom', () => {
+    const buttons = buttonsOf(buildCodeLimitRow(USER, seriesData, 9, 2));
+    expect(buttons.map(b => b.label)).toEqual(['Report Game 2', 'Go play a custom game']);
+    expect(buttons.map(b => parseButtonData(b.custom_id).tag)).toEqual([
+      'report_result',
+      'play_custom',
+    ]);
+  });
+
+  it('never offers a retry - the allowance clears on a result, not on a press', () => {
+    const labels = buttonsOf(buildCodeLimitRow(USER, seriesData, 9, 2)).map(b => b.label);
+    expect(labels).not.toContain('Try again');
+    expect(labels).not.toContain('Generate Next Game');
+  });
+
+  it('names the code a result would be credited to', () => {
+    const [report] = buttonsOf(buildCodeLimitRow(USER, seriesData, 9, 2));
+    expect(parseButtonData(report.custom_id).tagArg).toBe('9-2');
+  });
+
+  it('drops the report button when no code is outstanding', () => {
+    const labels = buttonsOf(buildCodeLimitRow(USER, seriesData, null, 2)).map(b => b.label);
+    expect(labels).toEqual(['Go play a custom game']);
   });
 });
 

--- a/test/tournament.test.ts
+++ b/test/tournament.test.ts
@@ -40,8 +40,14 @@ const aSeries = (id: number, totalGames: number) => ({
 });
 let seriesCandidates: ReturnType<typeof aSeries>[] = [];
 
-/** Set to make the code request fail the way Riot being down makes it fail. */
-let issueFailsWith: { status: number } | null = null;
+/** Set to make the code request fail: Riot being down, or the allowance being spent. */
+let issueFailsWith: { status: number; body?: string } | null = null;
+
+/** Codes already issued against the series, for the allowance the 409 reports on. */
+let seriesCodes: { id: number; createdAt: string | null }[] = [];
+
+/** Set to make the read that follows a refused code fail too. */
+let seriesFailsToLoad = false;
 
 vi.mock('../src/dennys.ts', async importOriginal => {
   // nextGameNumber is pure, so keep the real one - the game number a captain
@@ -79,7 +85,8 @@ vi.mock('../src/dennys.ts', async importOriginal => {
     }),
     issueTournamentCode: vi.fn(async () => {
       calls.push('issueTournamentCode');
-      if (issueFailsWith) throw new HttpError('riot', issueFailsWith.status, '');
+      if (issueFailsWith)
+        throw new HttpError('riot', issueFailsWith.status, issueFailsWith.body ?? '');
       if (issueRecoversLostGame) seriesGames = [{ id: 4, seriesId: 756, number: 1 }];
       return {
         id: 9,
@@ -92,6 +99,7 @@ vi.mock('../src/dennys.ts', async importOriginal => {
     }),
     getSeries: vi.fn(async (id: number) => {
       calls.push('getSeries');
+      if (seriesFailsToLoad) throw new HttpError('series', 500, '');
       return {
         id,
         eventId: 7,
@@ -101,7 +109,7 @@ vi.mock('../src/dennys.ts', async importOriginal => {
         completed: false,
         completedAt: null,
         reopenedAt: null,
-        tournamentCodes: [],
+        tournamentCodes: seriesCodes,
         games: seriesGames,
         lastCodeIssuedAt: null,
         lastGameAt: null,
@@ -240,6 +248,8 @@ beforeEach(() => {
   issueRecoversLostGame = false;
   seriesCandidates = [aSeries(756, 3)];
   issueFailsWith = null;
+  seriesCodes = [];
+  seriesFailsToLoad = false;
 });
 
 describe('handleBothTeamSubmission acknowledges before touching dennys', () => {
@@ -423,6 +433,98 @@ describe('Riot refusing a code at game 1', () => {
 
     expect(threadSends[0]).toContain('Riot');
     expect(threadSends[0]).not.toContain('matching series');
+  });
+});
+
+/**
+ * Dennys 1.4.1 answers 409 once a game has taken its codes, counted since the
+ * most recent recorded game (todd-bot#126). Another press cannot clear it, so
+ * the captain gets the message dennys wrote and the two things that can.
+ */
+describe('dennys refusing a code because the allowance is spent', () => {
+  const MESSAGE = "Series '756' has already been issued 2 tournament code(s).";
+
+  beforeEach(() => {
+    issueFailsWith = { status: 409, body: JSON.stringify({ code: 409, message: MESSAGE }) };
+    seriesCodes = [
+      { id: 8, createdAt: '2026-08-09T11:00:00Z' },
+      { id: 9, createdAt: '2026-08-09T12:00:00Z' },
+    ];
+  });
+
+  it('shows what dennys said, not generic failure text', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(threadSends[0]).toContain(MESSAGE);
+    expect(threadSends[0]).not.toContain('An error occurred');
+  });
+
+  it('opens the thread anyway, so the series has somewhere to be played out', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(interaction.followUp).toHaveBeenCalled();
+    expect(threadSends).toHaveLength(1);
+  });
+
+  it('offers both remedies and no retry', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const labels = (threadComponents[0][0] as any)
+      .toJSON()
+      .components.map((b: { label: string }) => b.label);
+    expect(labels).toEqual(['Report Game 1', 'Go play a custom game']);
+  });
+
+  it('points the report button at the code still outstanding', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [report] = (threadComponents[0][0] as any).toJSON().components;
+    const parsed = parseButtonData(report.custom_id);
+    expect(parsed.tag).toBe('report_result');
+    expect(parsed.tagArg).toBe('9-1');
+    expect(parsed.seriesData.seriesId).toBe(756);
+  });
+
+  it('asks dennys once - pressing again cannot clear the allowance', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(calls.filter(c => c === 'issueTournamentCode')).toHaveLength(1);
+  });
+
+  it('falls back to its own wording when dennys sends no message', async () => {
+    issueFailsWith = { status: 409, body: 'Conflict' };
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(threadSends[0]).toContain('No more codes can be issued for this game');
+  });
+
+  it('drops the report button when the series cannot be read back', async () => {
+    // The custom game is still the way forward; only the button that has to
+    // name a code goes with the failed lookup.
+    seriesFailsToLoad = true;
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const labels = (threadComponents[0][0] as any)
+      .toJSON()
+      .components.map((b: { label: string }) => b.label);
+    expect(labels).toEqual(['Go play a custom game']);
   });
 });
 


### PR DESCRIPTION
## Why

Dennys 1.4.1 caps tournament codes at two per game, counted since the most recent recorded game, and answers `409 { code, message }` past that. Todd had no idea: `issueTournamentCode` (`src/dennys.ts`) throws an `HttpError` on any non-2xx, and `getTournamentCode` (`src/commands/tournament.ts`) only classifies 502/503 as something worth explaining — everything else falls through to the outer catch in `handleBothTeamSubmission` / `handleGenerateAnotherConfirm` and surfaces as *"There was an error generating a new tournament code."* The captain is told nothing about why, and nothing about what would fix it. The two things that actually clear a spent allowance — reporting the result of a game already played, or playing a custom and reporting the winner — were both reachable only by guessing, and the one button still on screen (Generate Next Game) was the one guaranteed to fail again.

Worse on the first-game path: a 409 on `/start-series` aborted before the thread was ever opened, so a series whose codes had run out had nowhere to be played out from at all.

## Solution

Mirror the shape the Riot-outage path already uses. `isCodeLimitError` classifies the 409 and `dennysErrorMessage` pulls `message` out of the body (mojibake-repaired like every other string from dennys, capped at 500 chars); `getTournamentCode` returns `codeLimitReached: true` carrying that message verbatim plus the outstanding code id and the game number, instead of throwing. Both call sites render `buildCodeLimitRow` (`src/seriesControl.ts`) — **Report Game N**, a `report_result` button naming the code still outstanding, and **Go play a custom game**, which rejoins the existing custom flow. The row is posted under `RECOVERY_MARKER`, so the first result to land retires both buttons. As on the 502 path, a refusal at game 1 still opens the thread.

Nothing on this path retries. `apiSend` already passes `retries: 0` and 409 is not a retryable status in `fetchWithRetry`, so the only change needed was to not offer a **Try again** button — the allowance lifts when a result is written, not when the button is pressed again.

The optional half of the ticket is included: `remainingCodeAllowance` counts codes whose `createdAt` is after `lastGameAt` — the same rule dennys applies — so the status line warns at one code left (every game with a code out, under a two-code cap), explains at zero, and `buildControlRow` greys out Generate Next Game there. It returns null when the count cannot be worked out, and null means say nothing and leave the button live; a guess that reads low would lock captains out of a code they are owed, and dennys stays the authority. That null is why `TournamentCodeDto.createdAt` moved to a new `advisory()` wrapper rather than becoming a required field: requiring it would raise `DennysSchemaError` on the code issue itself and take the whole flow down over a line of status text.

## Acceptance Criteria

- A 409 renders the message dennys wrote — it names the series and the count — with Todd's guidance appended, not generic failure text
- Both remedies are presented as buttons: report the result of the game already played, or play a custom game and report the winner
- No automatic retry, and no **Try again** button anywhere on this path
- A 409 at game 1 still opens the thread, so the series has somewhere to be played out
- Todd falls back to its own wording when dennys sends a body it does not recognise, and drops the report button when the series cannot be read back
- Optional/preferred: the status line shows the remaining allowance at one code left (every game with a code out, under a two-code cap) and at zero, where Generate Next Game is greyed out; an unknown count says nothing and leaves the button live
- The Riot 502/503 paths, `buildRecoveryRow` and the "Code not working?" gating are untouched

**Verification:** 26 new cases across `test/dennys.test.ts`, `test/tournament.test.ts`, `test/generateAnotherConfirm.test.ts` and `test/seriesControl.test.ts` fail against pre-fix `src/` and pass with the fix. Full suite 393 passing, `npm run typecheck` clean, no new lint warnings. Docs updated: new *When Dennys will not issue another code* section in `docs/ARCHITECTURE.md`, the `advisory()` note under validation, the contract bumped to 1.4.1, and the message row in `docs/COMMANDS.md`.

Closes #126.