### PR TITLE
fix: Say the code refusal once, and gate the right button

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -410,10 +410,21 @@ never played leaves no game behind, so a captain pressing Generate could go roun
 forever.
 
 `isCodeLimitError` classifies it and `dennysErrorMessage` pulls the message out
-of the body. **The message is shown verbatim** — it names the series and the
-count, which is more use than anything Todd could write in its place — with
-Todd's own line appended for what to do next. `dennysErrorMessage` returns null
-for a body that is not that shape, leaving the caller on its own wording.
+of the body. **The message is shown as Dennys wrote it, minus the series id** —
+the count it names is more use than anything Todd could write in its place, but
+the id is not: captains know their series by the two teams in it, and a bare
+number in a failure message reads as something they are supposed to act on.
+`withoutSeriesId` rewrites Dennys's leading `Series '756' …` to `This game …` and
+strips a `for series 756` named mid-sentence; a message that never named one is
+passed through untouched. `dennysErrorMessage` returns null for a body that is
+not that shape, leaving the caller on its own wording.
+
+The refusal is said **once**, in the thread. Both captains need to see it and
+either may act on the buttons, so the handler posts there and deletes its
+ephemeral "Generating…" placeholder rather than rewriting it into a second copy
+of the same text. The thread send goes first: if it fails, the ephemeral is still
+standing to carry the news, and the fallback path uses it when there is no thread
+to post to at all.
 
 Two things follow from the cap only lifting when a result is written:
 
@@ -430,18 +441,30 @@ Todd counts the allowance itself so it can warn *before* the last code is spent.
 `remainingCodeAllowance` counts codes whose `createdAt` is after `lastGameAt` —
 the same rule Dennys applies — against `TOURNAMENT_CODE_LIMIT`. The status line
 says so at one remaining, which under a two-code cap is every game with a code
-out and reads as *your next code is the last one*, and at zero, where it also
-greys out Generate Next Game. It returns **null when the count cannot be worked
-out**, and null means say nothing and leave the button live: the number gates a
-button, and a guess that reads low would lock captains out of a code they are
-owed. Dennys is still the authority, and the 409 path above is what catches the
-cases Todd's count misses.
+out and reads as *your next code is the last one*, and at zero. It returns **null
+when the count cannot be worked out**, and null means say nothing and leave every
+button live: the number gates a button, and a guess that reads low would lock
+captains out of a code they are owed. Dennys is still the authority, and the 409
+path above is what catches the cases Todd's count misses.
+
+Which button the count gates is the part worth getting right, and the two are not
+the same:
+
+- **Generate Next Game is never gated.** It asks for the *next* game, and
+  reporting the current one is what a captain does immediately before pressing
+  it — the same act that clears the allowance. Greying it out put the exit behind
+  a disabled button and made a spent allowance look like a stuck series.
+- **"Generate a new one" is dropped from the "Code not working?" menu** at a
+  known zero, and the menu says why. That button asks for another code for the
+  game already in progress, which is exactly what Dennys is refusing, so offering
+  it can only spend a click on a 409. The custom-game exit stays, and it is the
+  one the wording points at.
 
 `TOURNAMENT_CODE_LIMIT` is Todd's copy of a server-side rule, so the two can
-drift. Setting it *below* what Dennys enforces is safe — the button greys out a
-code early and the 409 path never fires — but setting it above means the status
-line promises a code Dennys will refuse. Dennys's own message is always shown
-verbatim, so the captain reads the real count either way.
+drift. Setting it *below* what Dennys enforces is safe — the replacement button
+disappears early and the 409 path never fires — but setting it above means the
+status line promises a code Dennys will refuse. Dennys's own message is always
+shown, so the captain reads the real count either way.
 
 That null is why `tournamentCode.createdAt` is wrapped in `advisory()` rather
 than being required — see [Validation at the boundary](#validation-at-the-boundary).

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -81,7 +81,7 @@ them get to drive the series buttons afterward.
 | *"Failed to find a matching series for these teams."* | Dennys has no scheduled series for that pairing in that stage, or the only one is already complete — the lookup sends `completed=false`. |
 | *"Riot is not answering right now..."* | Riot returned 503. The thread is opened anyway with **Try again** and **Go play a custom game**. |
 | *"Riot refused to create a code for this game."* | Riot returned 502, which will not succeed on a retry, so only the custom path is offered. |
-| *"Series 'N' has already been issued 2 tournament code(s)…"* | Dennys 409: this game has spent its code allowance. The message is Dennys's own, and the thread is opened anyway with **Report Game N** and **Go play a custom game**. No retry is offered — the allowance clears when a result is written. |
+| *"This game has already been issued 2 tournament code(s)…"* | Dennys 409: this game has spent its code allowance. The message is Dennys's own with the series id taken out, posted once in the thread with **Report Game N** and **Go play a custom game**. No retry is offered — the allowance clears when a result is written. |
 | *"Error generating draft links! Please do so manually :)"* | The draft backend failed. **The tournament code was still created** — only the draft links are missing. |
 
 **Timeouts:** the dropdown collectors live for 5 minutes. After that the menus go

--- a/src/buttons/handlers/generateAnotherConfirm.ts
+++ b/src/buttons/handlers/generateAnotherConfirm.ts
@@ -91,14 +91,9 @@ export async function handleGenerateAnotherConfirm(interaction: ButtonInteractio
       return;
     }
 
-    // Dennys refused: this game has used its code allowance. The remedies go in
-    // the thread, where both captains can see them and either can act.
+    // Dennys refused: this game has used its code allowance. Said once, in the
+    // thread, where both captains can see it and either can act on the buttons.
     if (tournamentCode.codeLimitReached) {
-      await interaction.editReply({
-        content: tournamentCode.error!,
-        components: [],
-      });
-
       const limitThread = interaction.channel;
       if (limitThread && 'send' in limitThread) {
         await limitThread.send({
@@ -112,7 +107,15 @@ export async function handleGenerateAnotherConfirm(interaction: ButtonInteractio
             ),
           ],
         });
+        // Posted first, so a failed send leaves the ephemeral to carry the news.
+        await interaction.deleteReply();
+        return;
       }
+
+      await interaction.editReply({
+        content: tournamentCode.error!,
+        components: [],
+      });
       return;
     }
 

--- a/src/buttons/handlers/recovery.ts
+++ b/src/buttons/handlers/recovery.ts
@@ -1,6 +1,7 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonInteraction, ButtonStyle, MessageFlags } from 'discord.js';
 import { createButton, createButtonData, parseButtonData } from '../button.ts';
 import { safeDefer, safeInteractionError } from '../../interactionSafety.ts';
+import { getSeries, remainingCodeAllowance } from '../../dennys.ts';
 import {
   CUSTOM_MARKER,
   encodeReportTarget,
@@ -47,16 +48,26 @@ export async function handleCodeNotWorking(interaction: ButtonInteraction) {
     if (!mayAct(interaction, data.originalUserId, seriesData.enemyCaptainId)) return refuse(interaction);
     if (!(await safeDefer(interaction, { ephemeral: true }))) return;
 
-    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      // regenerate_confirm, not generate_another_confirm: reaching this button
-      // means the captain has declared the current code dead, which is the only
-      // thing that licenses removing its message from the thread.
-      createButton(
-        createButtonData('regenerate_confirm', data.originalUserId, seriesData),
-        'Generate a new one',
-        ButtonStyle.Primary,
-        '🔄',
-      ),
+    // A read, and an unknown allowance leaves the option up: dennys is the
+    // authority, and offering a code it refuses beats hiding one it would issue.
+    const series = await getSeries(seriesData.seriesId).catch(() => null);
+    const spent = series !== null && remainingCodeAllowance(series) === 0;
+
+    const row = new ActionRowBuilder<ButtonBuilder>();
+    if (!spent) {
+      row.addComponents(
+        // regenerate_confirm, not generate_another_confirm: reaching this button
+        // means the captain has declared the current code dead, which is the only
+        // thing that licenses removing its message from the thread.
+        createButton(
+          createButtonData('regenerate_confirm', data.originalUserId, seriesData),
+          'Generate a new one',
+          ButtonStyle.Primary,
+          '🔄',
+        ),
+      );
+    }
+    row.addComponents(
       createButton(
         createButtonData('play_custom', data.originalUserId, seriesData),
         'Go play a custom game',
@@ -72,9 +83,11 @@ export async function handleCodeNotWorking(interaction: ButtonInteraction) {
     );
 
     await interaction.editReply({
-      content:
-        'You may either regenerate a new code to use OR play a custom.\n' +
-        'If regenerating a code fails for any reason, please use a custom game.',
+      content: spent
+        ? 'No more codes can be issued for this game.\n' +
+          '**Play a custom game and report the winner.**'
+        : 'You may either regenerate a new code to use OR play a custom.\n' +
+          'If regenerating a code fails for any reason, please use a custom game.',
       components: [row],
     });
   } catch (error) {

--- a/src/commands/tournament.ts
+++ b/src/commands/tournament.ts
@@ -654,8 +654,8 @@ export async function getTournamentCode({
         gameNumber: Math.max(1, limited ? nextGameNumber(limited) : 1, postedSoFar),
         error:
           `${dennysErrorMessage(error) ?? 'No more codes can be issued for this game.'}\n\n` +
-          'Another code will not help. Report the result of the game you already played, ' +
-          'or play a custom game and report the winner.',
+          'Another code will not help. **Report the result of the game you already played, ' +
+          'or play a custom game and report the winner.**',
         divisionId: division,
         divisionName: divisionEvent?.name,
         stageName: selectedStage,

--- a/src/dennys.ts
+++ b/src/dennys.ts
@@ -323,12 +323,19 @@ export const TOURNAMENT_CODE_LIMIT = 2;
 export const isCodeLimitError = (error: unknown): error is HttpError =>
   error instanceof HttpError && error.status === 409;
 
+/** Dennys names series by id; captains know them by team. See docs/ARCHITECTURE.md. */
+const withoutSeriesId = (message: string): string =>
+  message
+    .replace(/^series\s+['"]?\d+['"]?\s+/i, 'This game ')
+    .replace(/\s*\bfor\s+series\s+['"]?\d+['"]?/gi, '');
+
 /** What dennys said, from its `{ code, message }` error body. Null if it did not say. */
 export const dennysErrorMessage = (error: unknown): string | null => {
   if (!(error instanceof HttpError) || !error.body) return null;
   try {
     const parsed = normalizeApiStrings(JSON.parse(error.body) as { message?: unknown });
-    const message = typeof parsed?.message === 'string' ? parsed.message.trim() : '';
+    const raw = typeof parsed?.message === 'string' ? parsed.message.trim() : '';
+    const message = withoutSeriesId(raw).trim();
     if (!message) return null;
     return message.length > 500 ? `${message.slice(0, 500)}…` : message;
   } catch {

--- a/src/seriesControl.ts
+++ b/src/seriesControl.ts
@@ -247,13 +247,14 @@ export function buildSeriesStatus(
     lines.push('The last code has no result yet.');
   }
 
-  // At zero this is why the button below is greyed. At one it is the warning
-  // that the next code is the last one - a two-code cap leaves no earlier point.
+  // At zero this is why "Code not working?" stops offering a new code. At one it
+  // is the warning that the next code is the last - a two-code cap leaves no
+  // earlier point to say it.
   const remaining = remainingCodeAllowance(series);
   if (remaining === 0) {
     lines.push(
       `No more codes can be issued for this game — ${TOURNAMENT_CODE_LIMIT} have already gone out. ` +
-        'Report a result, or play a custom game.',
+        '**Report a result, or play a custom game.**',
     );
   } else if (remaining === 1) {
     lines.push('One more code can be issued for this game.');
@@ -278,18 +279,16 @@ export function buildControlRow(
   seriesData: SeriesData,
   series?: SeriesWithGames,
 ): ActionRowBuilder<ButtonBuilder> {
-  const generate = createButton(
-    createButtonData('generate_another', originalUserId, seriesData),
-    'Generate Next Game',
-    ButtonStyle.Success,
-    '⚔️',
+  // Never gated on the allowance. This asks for the next game, and reporting the
+  // current one is what a captain does immediately before pressing it.
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    createButton(
+      createButtonData('generate_another', originalUserId, seriesData),
+      'Generate Next Game',
+      ButtonStyle.Success,
+      '⚔️',
+    ),
   );
-
-  // Greyed rather than dropped, and only on a known zero - an unknown allowance
-  // leaves it live and lets dennys be the one to refuse.
-  if (series && remainingCodeAllowance(series) === 0) generate.setDisabled(true);
-
-  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(generate);
 
   // Not gated on staleness - staleness exists to give Riot's callback time to
   // land, but a dead code can be known immediately (League client says "invalid

--- a/test/dennys.test.ts
+++ b/test/dennys.test.ts
@@ -441,10 +441,24 @@ describe('the tournament code allowance', () => {
     expect(isCodeLimitError(new Error('network'))).toBe(false);
   });
 
-  it("hands back dennys's own message, which names the series and the count", () => {
+  it("hands back dennys's own message, with the count it names", () => {
     expect(dennysErrorMessage(new HttpError('nope', 409, LIMIT_BODY))).toBe(
-      "Series '756' has already been issued 2 tournament code(s).",
+      'This game has already been issued 2 tournament code(s).',
     );
+  });
+
+  it('drops the series id dennys leads with - captains know series by team', () => {
+    expect(dennysErrorMessage(new HttpError('nope', 409, LIMIT_BODY))).not.toContain('756');
+  });
+
+  it('drops a series id named mid-sentence too', () => {
+    const body = JSON.stringify({ code: 409, message: 'No codes left for series 756.' });
+    expect(dennysErrorMessage(new HttpError('nope', 409, body))).toBe('No codes left.');
+  });
+
+  it('leaves a message that never named a series alone', () => {
+    const body = JSON.stringify({ code: 409, message: 'The allowance is spent.' });
+    expect(dennysErrorMessage(new HttpError('nope', 409, body))).toBe('The allowance is spent.');
   });
 
   it('repairs mojibake in the message, like every other string from dennys', () => {

--- a/test/generateAnotherConfirm.test.ts
+++ b/test/generateAnotherConfirm.test.ts
@@ -233,9 +233,9 @@ describe('a regenerate that succeeds', () => {
 describe('a mid-series regenerate dennys refuses on the code allowance', () => {
   const refused = {
     error:
-      "Series '756' has already been issued 2 tournament code(s).\n\n" +
-      'Another code will not help. Report the result of the game you already played, ' +
-      'or play a custom game and report the winner.',
+      'This game has already been issued 2 tournament code(s).\n\n' +
+      'Another code will not help. **Report the result of the game you already played, ' +
+      'or play a custom game and report the winner.**',
     riotUnavailable: false,
     retryable: false,
     codeLimitReached: true,
@@ -263,8 +263,42 @@ describe('a mid-series regenerate dennys refuses on the code allowance', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await handleGenerateAnotherConfirm(makeInteraction() as any);
 
-    expect(editReplyPayloads.at(-1)?.content).toContain('already been issued 2 tournament code(s)');
     expect(threadSends[0].content).toContain('already been issued 2 tournament code(s)');
+  });
+
+  it('says it once - the thread message, not an ephemeral copy as well', async () => {
+    getTournamentCode.mockResolvedValue(refused);
+    const interaction = makeInteraction();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleGenerateAnotherConfirm(interaction as any);
+
+    // The "Generating..." placeholder goes rather than being rewritten into a
+    // second copy of a message the thread already carries.
+    expect(interaction.deleteReply).toHaveBeenCalled();
+    expect(editReplyPayloads.map(p => p.content)).not.toContain(refused.error);
+  });
+
+  it('names no series id - captains know their series by team', async () => {
+    getTournamentCode.mockResolvedValue(refused);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleGenerateAnotherConfirm(makeInteraction() as any);
+
+    expect(threadSends[0].content).not.toContain('756');
+  });
+
+  it('falls back to the ephemeral when there is no thread to post to', async () => {
+    getTournamentCode.mockResolvedValue(refused);
+    const interaction = makeInteraction();
+    // A refusal with nowhere to post must still reach the captain who clicked.
+    (interaction as { channel: unknown }).channel = null;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleGenerateAnotherConfirm(interaction as any);
+
+    expect(editReplyPayloads.at(-1)?.content).toBe(refused.error);
+    expect(interaction.deleteReply).not.toHaveBeenCalled();
   });
 
   it('leaves the report button out when no code is outstanding', async () => {

--- a/test/recovery.test.ts
+++ b/test/recovery.test.ts
@@ -3,11 +3,41 @@ import { SeriesData } from '../src/types/toddData.ts';
 import { createButtonData, parseButtonData } from '../src/buttons/button.ts';
 import { buildRecoveryRow } from '../src/seriesControl.ts';
 import { getButtonHandler } from '../src/buttons/handlers.ts';
-import {
-  handleCodeNotWorking,
-  handlePlayCustom,
-  handlePlayCustomConfirm,
-} from '../src/buttons/handlers/recovery.ts';
+
+/** Codes issued for the game in progress, which is what gates the replacement. */
+let seriesCodes: { id: number; createdAt: string | null }[] = [];
+/** Set to make the allowance unreadable, so dennys stays the authority. */
+let seriesFailsToLoad = false;
+
+vi.mock('../src/dennys.ts', async importOriginal => {
+  // remainingCodeAllowance is pure and covered by dennys.test.ts - keep the real
+  // one so what is stubbed here is only the read.
+  const actual = await importOriginal<typeof import('../src/dennys.ts')>();
+  return {
+    ...actual,
+    getSeries: vi.fn(async (id: number) => {
+      if (seriesFailsToLoad) throw new Error('dennys is down');
+      return {
+        id,
+        eventId: 7,
+        teamIds: [11, 22],
+        totalGames: 3,
+        eventStage: 'REGULAR_SEASON',
+        completed: false,
+        completedAt: null,
+        reopenedAt: null,
+        tournamentCodes: seriesCodes,
+        games: [],
+        lastCodeIssuedAt: null,
+        lastGameAt: null,
+      };
+    }),
+  };
+});
+
+const { handleCodeNotWorking, handlePlayCustom, handlePlayCustomConfirm } = await import(
+  '../src/buttons/handlers/recovery.ts'
+);
 
 /**
  * A dead code and a code that never generated are different failures with the
@@ -116,6 +146,8 @@ beforeEach(() => {
   editReplyPayloads.length = 0;
   threadSends.length = 0;
   threadMessages = [];
+  seriesCodes = [{ id: 9, createdAt: '2026-08-09T12:00:00Z' }];
+  seriesFailsToLoad = false;
 });
 
 describe('a code that will not generate', () => {
@@ -174,6 +206,32 @@ describe('a code that generated but does not work', () => {
     expect(getButtonHandler('regenerate_confirm')).toBe(
       getButtonHandler('generate_another_confirm'),
     );
+  });
+
+  it('drops the replacement once this game has spent its allowance', async () => {
+    // Dennys would refuse it, so offering it can only waste a click. The custom
+    // is the way out, and it is the one left on screen.
+    seriesCodes = [
+      { id: 8, createdAt: '2026-08-09T11:00:00Z' },
+      { id: 9, createdAt: '2026-08-09T12:00:00Z' },
+    ];
+    const interaction = makeInteraction('code_not_working');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleCodeNotWorking(interaction as any);
+
+    expect(labelsOf(editReplyPayloads.at(-1)!)).toEqual(['Go play a custom game', 'Cancel']);
+    expect(editReplyPayloads.at(-1)!.content).toContain('No more codes can be issued');
+    expect(editReplyPayloads.at(-1)!.content).not.toContain('regenerate');
+  });
+
+  it('keeps the replacement when the allowance cannot be read', async () => {
+    // A guess that reads low locks captains out of a code dennys would issue.
+    seriesFailsToLoad = true;
+    const interaction = makeInteraction('code_not_working');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleCodeNotWorking(interaction as any);
+
+    expect(labelsOf(editReplyPayloads.at(-1)!)).toContain('Generate a new one');
   });
 
   it('marks the replacement apart from Generate Next Game', async () => {

--- a/test/seriesControl.test.ts
+++ b/test/seriesControl.test.ts
@@ -374,9 +374,11 @@ describe('the code allowance', () => {
     expect(status).toContain('custom game');
   });
 
-  it('greys out Generate Next Game at zero rather than removing it', () => {
+  it('leaves Generate Next Game live at zero - it asks for the next game', () => {
+    // The allowance is per game and clears on a result, so a captain reporting
+    // and then pressing this is the ordinary way out. Greying it blocked that.
     expect(labelsOfControl(spent())).toContain('Generate Next Game');
-    expect(generateIsDisabled(spent())).toBe(true);
+    expect(generateIsDisabled(spent())).toBe(false);
   });
 
   it('counts only the codes issued since the last recorded game', () => {

--- a/test/tournament.test.ts
+++ b/test/tournament.test.ts
@@ -457,8 +457,28 @@ describe('dennys refusing a code because the allowance is spent', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await handleBothTeamSubmission(interaction as any);
 
-    expect(threadSends[0]).toContain(MESSAGE);
+    expect(threadSends[0]).toContain('already been issued 2 tournament code(s)');
     expect(threadSends[0]).not.toContain('An error occurred');
+  });
+
+  it("drops the series id out of dennys's wording", async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(threadSends[0]).toContain('This game has already been issued');
+    expect(threadSends[0]).not.toContain('756');
+  });
+
+  it('bolds the two things a captain can actually do', async () => {
+    const interaction = makeInteraction('confirm');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleBothTeamSubmission(interaction as any);
+
+    expect(threadSends[0]).toContain(
+      '**Report the result of the game you already played, ' +
+        'or play a custom game and report the winner.**',
+    );
   });
 
   it('opens the thread anyway, so the series has somewhere to be played out', async () => {


### PR DESCRIPTION
## Why

Three things about the 409 path shipped in #127 read badly in practice.

The refusal was said twice. `handleGenerateAnotherConfirm` rewrote its ephemeral "Generating new tournament code…" placeholder into the full failure text *and* posted the same text to the thread, so the captain who pressed the button read it once privately and once publicly, a line apart. Only the thread copy carries the buttons, so the ephemeral was pure duplication.

The text led with the series id, because it is Dennys's own wording: *"Series '756' has already been issued 2 tournament code(s)."* Captains do not identify a series by its id — they know it as the two teams in the thread they are already sitting in — so a bare number in a failure message reads as something they are supposed to do something about.

And the allowance gated the wrong button. `buildControlRow` greyed out **Generate Next Game** at zero, which is the one button on the path *out*: it asks for the next game, and reporting the current one is the act that clears the allowance. Greying it made a spent allowance look like a stuck series. The button that genuinely cannot work is **Generate a new one** on the "Code not working?" menu — that one asks for another code for the game already in progress, which is exactly what Dennys is refusing — and it was still being offered at full strength.

## Solution

The refusal is posted to the thread and the ephemeral placeholder is deleted, the same way the success path disposes of it. The thread send goes first, so a failed send leaves the ephemeral standing to carry the news, and the old `editReply` is kept as the fallback for when there is no thread to post to at all.

`dennysErrorMessage` now runs Dennys's message through `withoutSeriesId`, which rewrites a leading `Series '756' …` to `This game …` and strips a `for series 756` named mid-sentence. A message that never named a series is passed through untouched, and the count Dennys reports — the part worth showing — survives either way. The two remedies at the end are bold, in the thread message and on the status line both.

`buildControlRow` no longer consults the allowance at all: Generate Next Game is always live. `handleCodeNotWorking` reads the series and drops the **Generate a new one** button at a known zero, and its wording changes to say why and point at the custom. The read is best-effort — an allowance that cannot be worked out leaves the button up and lets Dennys be the one to refuse, which is the same direction `remainingCodeAllowance` returning null already meant everywhere else.

## Acceptance Criteria

- A refused code is announced once, in the thread, with the buttons; no ephemeral copy of the same text
- The message still reaches the captain who clicked when there is no thread to post to
- No series id appears in what a captain reads; the count Dennys reports still does
- *"Report the result of the game you already played, or play a custom game and report the winner."* is bold, as is the remedy sentence on the status line
- **Generate Next Game** is never disabled, at any allowance
- **Generate a new one** is dropped from the "Code not working?" menu at a known zero, with wording that says why; **Go play a custom game** and **Cancel** stay
- An unreadable allowance leaves every button live — Dennys stays the authority

**Verification:** 8 of the new/changed cases fail against pre-fix `src/` and pass with the fix, across `test/dennys.test.ts`, `test/tournament.test.ts`, `test/generateAnotherConfirm.test.ts`, `test/recovery.test.ts` and `test/seriesControl.test.ts`. Full suite 403 passing, `npm run typecheck` clean, no new lint warnings. Docs updated: the *When Dennys will not issue another code* section in `docs/ARCHITECTURE.md` now covers the id scrub, the say-it-once rule and which button the count gates; the failure row in `docs/COMMANDS.md` matches the new wording.

Follows up #127.