### PR TITLE
fix: Lock generation to one game at a time, and point at the post-game form

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,4 @@ RIOT_API_TOKEN=
 # STATE_DIR=./data       # where state.json (selected event group) is persisted
 # API_TIMEOUT_MS=20000   # per-attempt timeout on outbound HTTP; must be > 0
 # API_RETRIES=2          # retry budget, GET requests only; 0 disables retries
+# POST_GAME_FORM_URL=  # link posted when a series finishes; defaults to the current LBLCS form

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -471,7 +471,7 @@ That count is only meaningful because of the rule in
 *result*, not per game number, so a series that got a code for game 1 and a code
 for game 2 with nothing reported has "2 codes used" — and calling that "no more
 codes **for this game**" mis-attributes a series-wide condition to the game a
-captain is looking at (todd-bot#129). With generation locked to one game at a
+captain is looking at. With generation locked to one game at a
 time, every code counted since the last result genuinely belongs to the game in
 progress, and the line means what it says. **Zero can only be reached through
 Code not working? → Generate a new one**, which is exactly the button it explains

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -430,7 +430,7 @@ Two things follow from the cap only lifting when a result is written:
 
 - **Never retried, and no Try again button.** Unlike a 503 there is no moment at
   which the same press starts working, so `buildCodeLimitRow` offers only the two
-  things that clear it: **Report Game N**, which credits a result to the code
+  things that clear it: **Verify Game N Stats**, which credits a result to the code
   still outstanding (`outstandingCodeId`), and **Go play a custom game**, which
   rejoins the ordinary custom flow. The row is posted with `RECOVERY_MARKER`, so
   the first result to land retires both buttons.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -353,6 +353,28 @@ Code blocks and draft links are permanent. The control message is safe to delete
 precisely because everything on it is regenerated from `getSeries` on the next
 post.
 
+### When the series finishes
+
+`announceSeriesFinished` posts the post-game form the moment `series.completed`
+comes back true. This is the one message in the thread that is not about Todd:
+**nothing Todd writes reaches the standings** — the form is what records the
+match — so it carries the warning that results are not recorded without it, and
+names the winning captain as the one to fill it in. The URL comes from
+`POST_GAME_FORM_URL`, which is optional and defaults to the current form, so a
+new season is a config change rather than a deploy.
+
+It is posted **before** the control message, so the controls stay last, and it
+carries no buttons: there is nothing left to press in Discord.
+
+Once, guarded by `FINISHED_MARKER` — a scan of the thread rather than "did this
+click complete the series". Riot's callback closes a series with nobody pressing
+anything, so the completing click is not something Todd can rely on seeing;
+that is also why the decline path in `handleReportResult` (*"already
+recorded"*) announces too, since a captain pressing Verify Stats is often how
+Todd first learns the final game landed. If the thread cannot be read, it posts
+anyway — a duplicate reminder costs a scroll, and staying quiet costs the match
+result.
+
 ### Reporting a result
 
 Dennys pulls a played game from Riot whenever a code is issued, so a lost

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -437,34 +437,58 @@ Two things follow from the cap only lifting when a result is written:
 - **A refusal at game 1 still opens the thread**, for the same reason a Riot
   outage does: the series has to be played out somewhere.
 
-Todd counts the allowance itself so it can warn *before* the last code is spent.
-`remainingCodeAllowance` counts codes whose `createdAt` is after `lastGameAt` —
-the same rule Dennys applies — against `TOURNAMENT_CODE_LIMIT`. The status line
-says so at one remaining, which under a two-code cap is every game with a code
-out and reads as *your next code is the last one*, and at zero. It returns **null
-when the count cannot be worked out**, and null means say nothing and leave every
-button live: the number gates a button, and a guess that reads low would lock
-captains out of a code they are owed. Dennys is still the authority, and the 409
-path above is what catches the cases Todd's count misses.
+Todd counts the allowance itself so it can explain the refusal before the 409
+arrives. `remainingCodeAllowance` counts codes whose `createdAt` is after
+`lastGameAt` — the same rule Dennys applies — against `TOURNAMENT_CODE_LIMIT`,
+and the status line speaks at zero. It returns **null when the count cannot be
+worked out**, and null means say nothing: a guess that reads low would announce a
+limit Dennys is not applying, and Dennys is the authority either way.
 
-Which button the count gates is the part worth getting right, and the two are not
-the same:
-
-- **Generate Next Game is never gated.** It asks for the *next* game, and
-  reporting the current one is what a captain does immediately before pressing
-  it — the same act that clears the allowance. Greying it out put the exit behind
-  a disabled button and made a spent allowance look like a stuck series.
-- **"Generate a new one" is dropped from the "Code not working?" menu** at a
-  known zero, and the menu says why. That button asks for another code for the
-  game already in progress, which is exactly what Dennys is refusing, so offering
-  it can only spend a click on a 409. The custom-game exit stays, and it is the
-  one the wording points at.
+That count is only meaningful because of the rule in
+[One game at a time](#one-game-at-a-time). Dennys counts codes since the last
+*result*, not per game number, so a series that got a code for game 1 and a code
+for game 2 with nothing reported has "2 codes used" — and calling that "no more
+codes **for this game**" mis-attributes a series-wide condition to the game a
+captain is looking at (todd-bot#129). With generation locked to one game at a
+time, every code counted since the last result genuinely belongs to the game in
+progress, and the line means what it says. **Zero can only be reached through
+Code not working? → Generate a new one**, which is exactly the button it explains
+the absence of.
 
 `TOURNAMENT_CODE_LIMIT` is Todd's copy of a server-side rule, so the two can
 drift. Setting it *below* what Dennys enforces is safe — the replacement button
 disappears early and the 409 path never fires — but setting it above means the
 status line promises a code Dennys will refuse. Dennys's own message is always
 shown, so the captain reads the real count either way.
+
+### One game at a time
+
+**Generate Next Game is greyed out while a game is in progress**, and reporting
+that game is what frees it. `buildControlRow` gates it on `hasOutstandingCode` —
+the same predicate that shows **Code not working?** — so the row always carries
+exactly one live button, never two and never none.
+
+"Reported" here means any of the three ways a game can land, because
+`hasOutstandingCode` reads the series rather than the clicks: the captain pressing
+Report, Riot's callback recording the game with nobody pressing anything, or a
+custom being reported (which records a game with no code on it, so only the
+timestamp ordering shows it). Todd catches up whenever the thread is next
+touched, and the sweeps that retire buttons run in the same pass as the control
+message being rebuilt — so a retired Report button and a greyed Generate can
+never be the final state.
+
+Two things fall out of it, and both were bugs before:
+
+- **The code allowance becomes countable**, as above.
+- **A replacement code has exactly one door.** "Code not working?" is the only
+  route to a second code for the same game, which is what makes a spent allowance
+  mean a captain actually regenerated rather than merely played two games without
+  reporting.
+
+A disabled button explains nothing on its own, so the status line carries *"Report
+the game in progress to unlock the next one — use the Report button on its code
+message above"* whenever it is greyed. Without it, "not yet" and "Todd is broken"
+look identical.
 
 That null is why `tournamentCode.createdAt` is wrapped in `advisory()` rather
 than being required — see [Validation at the boundary](#validation-at-the-boundary).

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -65,6 +65,8 @@ them get to drive the series buttons afterward.
      the enemy captain;
    - the game code message with the tournament code, who generated it, and the
      enemy captain;
+   - once the series is decided, a **post-game form** message — the form is what
+     records the match in the standings, and the winning captain fills it in;
    - a **control message**, always last, carrying the series status and the
      buttons. It is deleted and re-posted after every code so it stays at the
      bottom, which means exactly one set of buttons is ever live.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -166,7 +166,7 @@ lookup table is [src/buttons/handlers.ts](../src/buttons/handlers.ts).
 | `confirm` | ✅ Confirm | `handleBothTeamSubmission` | Creates the game and posts the series. |
 | `switch` | 🔄 Switch Sides | `handleTeamSelect` | Swaps blue/red during initial setup and re-renders. |
 | `cancel` | ❌ Cancel | `handleTeamSelect` | Clears both teams and the stage during setup. |
-| `generate_another` | ⚔️ Generate Next Game | `handleGenerateAnotherCode` | Shows the current sides with confirm/switch/cancel. |
+| `generate_another` | ⚔️ Generate Next Game | `handleGenerateAnotherCode` | Shows the current sides with confirm/switch/cancel. **Greyed out while a game is in progress** — reporting that game unlocks it. |
 | `cancel_switch` | — | `handleGenerateAnotherCode` | Alias of the above; returns to the sides prompt. |
 | `generate_another_confirm` | ✅ Confirm | `handleGenerateAnotherConfirm` | Creates the next game in the series and posts its code. |
 | `switch_sides` | 🔄 Switch Sides | `handleSwitchSides` | Swaps sides for the *next* game and re-confirms. |
@@ -174,7 +174,7 @@ lookup table is [src/buttons/handlers.ts](../src/buttons/handlers.ts).
 | `report_result` | 📝 Report result | `handleReportResult` | Opens the winner picker. Only on the control message, and only once the newest code has gone unanswered. |
 | `report_team1_won` | 🟦 *<blue team>* won | `handleReportTeam1Won` | Records the winner and refreshes the thread. |
 | `report_team2_won` | 🟥 *<red team>* won | `handleReportTeam2Won` | As above, for the other team. |
-| `code_not_working` | ❓ Code not working? | `handleCodeNotWorking` | Offers a replacement code or the custom-game path. |
+| `code_not_working` | ❓ Code not working? | `handleCodeNotWorking` | Offers a replacement code or the custom-game path. Shown exactly when Generate Next Game is greyed, and the only route to a second code for the same game. |
 | `play_custom` | ⚠️ Go play a custom game | `handlePlayCustom` | Confirms first: no stats, and take a scoreboard screenshot. |
 | `play_custom_confirm` | ✅ Yes, we're playing a custom | `handlePlayCustomConfirm` | Posts the *We finished the custom game* button into the thread. |
 | `end_series` | — | — | Retired. No button ever used it, and Dennys now closes a series automatically when enough results are written. The wire code stays reserved so a new tag cannot inherit it. |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -81,7 +81,7 @@ them get to drive the series buttons afterward.
 | *"Failed to find a matching series for these teams."* | Dennys has no scheduled series for that pairing in that stage, or the only one is already complete — the lookup sends `completed=false`. |
 | *"Riot is not answering right now..."* | Riot returned 503. The thread is opened anyway with **Try again** and **Go play a custom game**. |
 | *"Riot refused to create a code for this game."* | Riot returned 502, which will not succeed on a retry, so only the custom path is offered. |
-| *"This game has already been issued 2 tournament code(s)…"* | Dennys 409: this game has spent its code allowance. The message is Dennys's own with the series id taken out, posted once in the thread with **Report Game N** and **Go play a custom game**. No retry is offered — the allowance clears when a result is written. |
+| *"This game has already been issued 2 tournament code(s)…"* | Dennys 409: this game has spent its code allowance. The message is Dennys's own with the series id taken out, posted once in the thread with **Verify Game N Stats** and **Go play a custom game**. No retry is offered — the allowance clears when a result is written. |
 | *"Error generating draft links! Please do so manually :)"* | The draft backend failed. **The tournament code was still created** — only the draft links are missing. |
 
 **Timeouts:** the dropdown collectors live for 5 minutes. After that the menus go
@@ -171,7 +171,7 @@ lookup table is [src/buttons/handlers.ts](../src/buttons/handlers.ts).
 | `generate_another_confirm` | ✅ Confirm | `handleGenerateAnotherConfirm` | Creates the next game in the series and posts its code. |
 | `switch_sides` | 🔄 Switch Sides | `handleSwitchSides` | Swaps sides for the *next* game and re-confirms. |
 | `cancel_flow` | ❌ Cancel | `handleCancel` | Deletes the ephemeral confirmation. |
-| `report_result` | 📝 Report result | `handleReportResult` | Opens the winner picker. Only on the control message, and only once the newest code has gone unanswered. |
+| `report_result` | 📝 Verify Game N Stats | `handleReportResult` | Opens the winner picker. Only on the control message, and only once the newest code has gone unanswered. |
 | `report_team1_won` | 🟦 *<blue team>* won | `handleReportTeam1Won` | Records the winner and refreshes the thread. |
 | `report_team2_won` | 🟥 *<red team>* won | `handleReportTeam2Won` | As above, for the other team. |
 | `code_not_working` | ❓ Code not working? | `handleCodeNotWorking` | Offers a replacement code or the custom-game path. Shown exactly when Generate Next Game is greyed, and the only route to a second code for the same game. |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -78,8 +78,9 @@ fine for local development.
 | `STATE_DIR` | `<cwd>/data` | Directory holding `state.json`, where the selected event group is persisted |
 | `API_TIMEOUT_MS` | `20000` | Per-attempt timeout on every outbound HTTP call. Must be positive — `AbortSignal.timeout` has no "no timeout" value, so `0` is treated as a mistake, not as "disabled" |
 | `API_RETRIES` | `2` | Retry budget for **GET** requests only. Non-GET calls never retry unless a call site opts in. **`0` is honored** — it's the setting to reach for when retries are making an incident worse |
+| `POST_GAME_FORM_URL` | the current LBLCS form | The link Todd posts when a series finishes. Set it when the season rolls, so a new form does not need a deploy |
 
-Both are parsed in [src/config.ts](../src/config.ts), not at the point of use.
+These are parsed in [src/config.ts](../src/config.ts), not at the point of use.
 Unset and blank mean "use the default"; anything unparseable, negative, or (for
 the timeout) zero logs a warning and falls back rather than throwing — a typo in
 an optional knob shouldn't stop the bot from booting the way a missing required

--- a/src/buttons/handlers/reportResult.ts
+++ b/src/buttons/handlers/reportResult.ts
@@ -3,6 +3,7 @@ import { createButton, createButtonData, parseButtonData } from '../button.ts';
 import { getSeries, getTeam, reportSeriesResult } from '../../dennys.ts';
 import type { SeriesWithGames, Team } from '../../dennys.ts';
 import {
+  announceSeriesFinished,
   buildControlRow,
   buildSeriesStatus,
   clearRecoveryButtons,
@@ -15,6 +16,7 @@ import {
 } from '../../seriesControl.ts';
 import type { ControlThread } from '../../seriesControl.ts';
 import { safeDefer, safeInteractionError } from '../../interactionSafety.ts';
+import { config } from '../../config.ts';
 import log from 'loglevel';
 
 const logger = log.getLogger('reportResult');
@@ -115,10 +117,14 @@ export async function handleReportResult(interaction: ButtonInteraction) {
       // this is the first chance Todd has had to notice.
       const thread = interaction.channel;
       if (thread && 'send' in thread) {
-        await reconcileGameButtons(
-          thread as unknown as Parameters<typeof reconcileGameButtons>[0],
-          series,
-        );
+        const scan = shareThreadScan(thread as unknown as ControlThread);
+        await reconcileGameButtons(scan, series);
+
+        // Riot answering the final game closes the series without anyone
+        // reporting it, so this press is the first time Todd could have known.
+        if (series.completed) {
+          await announceSeriesFinished(scan, config.POST_GAME_FORM_URL);
+        }
       }
       return;
     }
@@ -275,6 +281,11 @@ async function report(interaction: ButtonInteraction, winner: 'team1' | 'team2')
       // among the ones still waiting - which is only true because the shared
       // scan carries their edits forward.
       const awaiting = await gamesAwaitingReport(scan, series);
+
+      // Before the control message, which has to stay last in the thread.
+      if (series.completed) {
+        await announceSeriesFinished(scan, config.POST_GAME_FORM_URL);
+      }
 
       await postSeriesControl(
         scan,

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,6 +39,11 @@ function optionalInt(name: string, fallback: number, isValid: (n: number) => boo
 const API_TIMEOUT_MS = optionalInt('API_TIMEOUT_MS', 20_000, n => n > 0);
 const API_RETRIES = optionalInt('API_RETRIES', 2, n => n >= 0);
 
+// The post-game form changes between seasons, so it is swappable without a
+// deploy. Optional: an unset or blank value keeps the current form.
+const POST_GAME_FORM_URL =
+  process.env.POST_GAME_FORM_URL?.trim() || 'https://forms.gle/bxYwXpe8esVpsoix6';
+
 const {
   DISCORD_TOKEN,
   DISCORD_CLIENT_ID,
@@ -81,4 +86,5 @@ export const config = {
   DENNYS_TOKEN,
   API_TIMEOUT_MS,
   API_RETRIES,
+  POST_GAME_FORM_URL,
 };

--- a/src/seriesControl.ts
+++ b/src/seriesControl.ts
@@ -228,8 +228,8 @@ export function buildSeriesStatus(
     const named = awaitingReport.map(number => `**Game ${number}**`).join(', ');
     lines.push(
       awaitingReport.length === 1
-        ? `${named} still needs a result — use the Report button on its code message above.`
-        : `${named} still need results — use the Report buttons on their code messages above.`,
+        ? `${named} still needs a result — use the Verify Stats button on its code message above.`
+        : `${named} still need results — use the Verify Stats buttons on their code messages above.`,
     );
   }
 
@@ -252,7 +252,7 @@ export function buildSeriesStatus(
   if (hasOutstandingCode(series)) {
     lines.push(
       '**Report the game in progress to unlock the next one** — ' +
-        'use the Report button on its code message above.',
+        'use the Verify Stats button on its code message above.',
     );
   }
 
@@ -384,7 +384,7 @@ export function buildGameReportRow(
         seriesData,
         encodeReportTarget(tournamentCodeId, gameNumber),
       ),
-      `Report Game ${gameNumber}`,
+      `Verify Game ${gameNumber} Stats`,
       ButtonStyle.Secondary,
       '📝',
     ),
@@ -443,7 +443,7 @@ export function buildCodeLimitRow(
           seriesData,
           encodeReportTarget(outstandingCodeId, gameNumber),
         ),
-        `Report Game ${gameNumber}`,
+        `Verify Game ${gameNumber} Stats`,
         ButtonStyle.Primary,
         '📝',
       ),

--- a/src/seriesControl.ts
+++ b/src/seriesControl.ts
@@ -247,17 +247,22 @@ export function buildSeriesStatus(
     lines.push('The last code has no result yet.');
   }
 
-  // At zero this is why "Code not working?" stops offering a new code. At one it
-  // is the warning that the next code is the last - a two-code cap leaves no
-  // earlier point to say it.
-  const remaining = remainingCodeAllowance(series);
-  if (remaining === 0) {
+  // Why Generate Next Game is greyed. A disabled button explains nothing on its
+  // own, and this is the one line that turns it from broken into "not yet".
+  if (hasOutstandingCode(series)) {
+    lines.push(
+      '**Report the game in progress to unlock the next one** — ' +
+        'use the Report button on its code message above.',
+    );
+  }
+
+  // Only at zero, which under one-game-at-a-time takes a regenerate to reach.
+  // This is why "Code not working?" stops offering a new code.
+  if (remainingCodeAllowance(series) === 0) {
     lines.push(
       `No more codes can be issued for this game — ${TOURNAMENT_CODE_LIMIT} have already gone out. ` +
         '**Report a result, or play a custom game.**',
     );
-  } else if (remaining === 1) {
-    lines.push('One more code can be issued for this game.');
   }
 
   return lines.join('\n');
@@ -279,16 +284,19 @@ export function buildControlRow(
   seriesData: SeriesData,
   series?: SeriesWithGames,
 ): ActionRowBuilder<ButtonBuilder> {
-  // Never gated on the allowance. This asks for the next game, and reporting the
-  // current one is what a captain does immediately before pressing it.
-  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    createButton(
-      createButtonData('generate_another', originalUserId, seriesData),
-      'Generate Next Game',
-      ButtonStyle.Success,
-      '⚔️',
-    ),
+  // One game at a time. See docs/ARCHITECTURE.md - this is also what keeps the
+  // code allowance countable.
+  const inProgress = series ? hasOutstandingCode(series) : false;
+
+  const generate = createButton(
+    createButtonData('generate_another', originalUserId, seriesData),
+    'Generate Next Game',
+    ButtonStyle.Success,
+    '⚔️',
   );
+  if (inProgress) generate.setDisabled(true);
+
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(generate);
 
   // Not gated on staleness - staleness exists to give Riot's callback time to
   // land, but a dead code can be known immediately (League client says "invalid
@@ -299,7 +307,10 @@ export function buildControlRow(
   // Not gated on completion either. Dennys does not block a completed series
   // from taking codes or results, and a captain who needs to correct one should
   // not be locked out because dennys closed it early.
-  if (series && hasOutstandingCode(series)) {
+  //
+  // The same condition that greys the button above, so the row always carries
+  // exactly one live button - never two, never none.
+  if (inProgress) {
     row.addComponents(
       createButton(
         createButtonData('code_not_working', originalUserId, seriesData),

--- a/src/seriesControl.ts
+++ b/src/seriesControl.ts
@@ -38,6 +38,12 @@ export const RECOVERY_MARKER = '⚠️';
  */
 export const CUSTOM_MARKER = '🎮';
 
+/**
+ * First line of the post-game form message, and the only thing stopping a
+ * second one. Nothing else Todd posts may start with it.
+ */
+export const FINISHED_MARKER = '# The series is finished!';
+
 /** Discord: the message is already gone, which the delete race below produces. */
 const UNKNOWN_MESSAGE = 10008;
 
@@ -485,6 +491,42 @@ export async function postSeriesControl(
     message => message.id !== posted.id && isControlMessage(message),
     message => message.delete(),
   );
+}
+
+/**
+ * Points at the post-game form once dennys closes the series.
+ *
+ * Nothing Todd writes reaches the standings - the form is what records the
+ * match - so this is the last thing the thread has to say and it must not be
+ * missed. Posted before the control message so the controls stay at the bottom.
+ *
+ * Posted once, guarded by FINISHED_MARKER rather than by "did this click
+ * complete the series": Riot's callback can close a series with nobody pressing
+ * anything, so the completing click is not a thing Todd can rely on seeing. A
+ * thread it cannot read is posted to anyway - a duplicate reminder costs a
+ * scroll, and staying quiet costs the match result.
+ */
+export async function announceSeriesFinished(
+  thread: ControlThread,
+  formUrl: string,
+): Promise<void> {
+  try {
+    const recent = await thread.messages.fetch({ limit: SCAN_LIMIT });
+    for (const message of recent.values()) {
+      if (message.content.startsWith(FINISHED_MARKER)) return;
+    }
+  } catch (error) {
+    logger.warn(`Could not check whether the series finish message is already up: ${String(error)}`);
+  }
+
+  await thread.send({
+    content:
+      `${FINISHED_MARKER} Please report the match results in the form!\n` +
+      '-# The match results will NOT be recorded if you do not fill out the sheet! ' +
+      'The winning captain needs to fill out the sheet\n\n' +
+      formUrl,
+    components: [],
+  });
 }
 
 /**

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -75,6 +75,26 @@ describe('API_TIMEOUT_MS', () => {
   });
 });
 
+describe('POST_GAME_FORM_URL', () => {
+  it('boots without it, rather than joining the required set', async () => {
+    // The deploy that does not know about this variable yet must still start.
+    const config = await loadConfigWith({ POST_GAME_FORM_URL: undefined });
+    expect(config.POST_GAME_FORM_URL).toBe('https://forms.gle/bxYwXpe8esVpsoix6');
+  });
+
+  it('treats a blank value as unset', async () => {
+    // `POST_GAME_FORM_URL=` in a .env file would otherwise post a bare heading
+    // with no link under it.
+    const config = await loadConfigWith({ POST_GAME_FORM_URL: '   ' });
+    expect(config.POST_GAME_FORM_URL).toBe('https://forms.gle/bxYwXpe8esVpsoix6');
+  });
+
+  it('takes a new form when the season rolls', async () => {
+    const config = await loadConfigWith({ POST_GAME_FORM_URL: 'https://forms.gle/next-season' });
+    expect(config.POST_GAME_FORM_URL).toBe('https://forms.gle/next-season');
+  });
+});
+
 describe('unparseable tunables', () => {
   it('falls back to the default without throwing', async () => {
     // A typo in an optional knob must not stop the bot from booting, unlike

--- a/test/generateAnotherConfirm.test.ts
+++ b/test/generateAnotherConfirm.test.ts
@@ -253,7 +253,7 @@ describe('a mid-series regenerate dennys refuses on the code allowance', () => {
     await handleGenerateAnotherConfirm(makeInteraction() as any);
 
     expect(threadSends).toHaveLength(1);
-    expect(labelsOf(threadSends[0])).toEqual(['Report Game 2', 'Go play a custom game']);
+    expect(labelsOf(threadSends[0])).toEqual(['Verify Game 2 Stats', 'Go play a custom game']);
     expect(tagsOf(threadSends[0])).toEqual(['report_result', 'play_custom']);
   });
 

--- a/test/reportResult.test.ts
+++ b/test/reportResult.test.ts
@@ -662,3 +662,74 @@ describe('recording the result', () => {
     expect(calls.indexOf('deferUpdate')).toBeLessThan(calls.indexOf('reportSeriesResult'));
   });
 });
+
+/**
+ * The form is what records the match in the standings - nothing Todd writes
+ * does - so the thread has to say so the moment dennys closes the series.
+ */
+describe('the series finishing', () => {
+  const finished = () =>
+    aSeries({
+      completed: true,
+      completedAt: '2026-08-09T13:00:00Z',
+      tournamentCodes: [aCode(1)],
+      games: [aGame(1, 11, 1), aGame(2, 11, null)],
+      lastCodeIssuedAt: '2026-08-09T12:00:00Z',
+      lastGameAt: '2026-08-09T12:40:00Z',
+    });
+
+  it('points at the post-game form once the result closes the series', async () => {
+    seriesState = finished();
+    const interaction = makeInteraction('report_team1_won');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleReportTeam1Won(interaction as any);
+
+    const finish = threadSends.find(s => s.content.startsWith('# The series is finished!'));
+    expect(finish).toBeDefined();
+    expect(finish!.content).toContain('will NOT be recorded');
+    expect(finish!.content).toContain('https://forms.gle/');
+  });
+
+  it('says nothing while the series is still going', async () => {
+    const interaction = makeInteraction('report_team1_won');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleReportTeam1Won(interaction as any);
+
+    expect(threadSends.some(s => s.content.includes('series is finished'))).toBe(false);
+  });
+
+  it('keeps the control message last, below the form', async () => {
+    // The controls are the bottom of the thread by convention, and a captain
+    // correcting a result still needs to reach them.
+    seriesState = finished();
+    const interaction = makeInteraction('report_team1_won');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleReportTeam1Won(interaction as any);
+
+    const finish = threadSends.findIndex(s => s.content.startsWith('# The series is finished!'));
+    const control = threadSends.findIndex(s => s.content.startsWith('## 📋 Series status'));
+    expect(finish).toBeGreaterThanOrEqual(0);
+    expect(control).toBeGreaterThan(finish);
+  });
+
+  it('says it when Riot closed the series with nobody reporting', async () => {
+    // The captain presses Verify Stats, dennys says the game is already in -
+    // and that game was the one that finished the series.
+    seriesState = { ...alreadyReported(), completed: true };
+    const interaction = makeInteraction('report_result', ORIGINAL_USER, [], '2-2');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleReportResult(interaction as any);
+
+    expect(threadSends.some(s => s.content.startsWith('# The series is finished!'))).toBe(true);
+  });
+
+  it('does not repeat itself when the form message is already in the thread', async () => {
+    seriesState = finished();
+    const already = aThreadMessage('9', '# The series is finished! Please report the match results in the form!');
+    const interaction = makeInteraction('report_team1_won', ORIGINAL_USER, [already]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleReportTeam1Won(interaction as any);
+
+    expect(threadSends.filter(s => s.content.includes('series is finished'))).toHaveLength(0);
+  });
+});

--- a/test/seriesControl.test.ts
+++ b/test/seriesControl.test.ts
@@ -477,7 +477,7 @@ describe('buildCodeLimitRow', () => {
 
   it('offers both remedies: report what was played, or play a custom', () => {
     const buttons = buttonsOf(buildCodeLimitRow(USER, seriesData, 9, 2));
-    expect(buttons.map(b => b.label)).toEqual(['Report Game 2', 'Go play a custom game']);
+    expect(buttons.map(b => b.label)).toEqual(['Verify Game 2 Stats', 'Go play a custom game']);
     expect(buttons.map(b => parseButtonData(b.custom_id).tag)).toEqual([
       'report_result',
       'play_custom',
@@ -787,7 +787,7 @@ describe('report targets', () => {
 
   it('puts the target on the button, so the press that writes knows the game', () => {
     const [button] = buttonsOf(buildGameReportRow('123456789012345678', seriesData, 42, 3));
-    expect(button.label).toBe('Report Game 3');
+    expect(button.label).toBe('Verify Game 3 Stats');
     const parsed = parseButtonData(button.custom_id);
     expect(parsed.tag).toBe('report_result');
     expect(decodeReportTarget(parsed.tagArg)).toEqual({ tournamentCodeId: 42, gameNumber: 3 });

--- a/test/seriesControl.test.ts
+++ b/test/seriesControl.test.ts
@@ -337,17 +337,12 @@ describe('buildControlRow', () => {
  * are left before a captain spends the last one.
  */
 describe('the code allowance', () => {
-  const USER = '123456789012345678';
+  /** Two codes for one game, which takes a regenerate to arrive at. */
   const spent = () =>
     aSeries({
       tournamentCodes: [aCode(1, ago(2000)), aCode(2, ago(1000))],
       lastCodeIssuedAt: ago(1000),
     });
-  const labelsOfControl = (series?: SeriesWithGames) =>
-    buttonsOf(buildControlRow(USER, seriesData, series)).map(b => b.label);
-  const generateIsDisabled = (series?: SeriesWithGames) =>
-    (buttonsOf(buildControlRow(USER, seriesData, series))[0] as { disabled?: boolean }).disabled ===
-    true;
 
   it('says nothing before a code has gone out for this game', () => {
     // Both codes belong to the game already in the books, so the game in
@@ -357,14 +352,7 @@ describe('the code allowance', () => {
       games: [aGame(1, 11, 2)],
       lastGameAt: ago(3000),
     });
-    const status = buildSeriesStatus(series, TEAMS, NOW);
-    expect(status).not.toContain('No more codes');
-    expect(status).not.toContain('One more code');
-  });
-
-  it('warns when one code is left', () => {
-    const series = aSeries({ tournamentCodes: [aCode(1, ago(1000))] });
-    expect(buildSeriesStatus(series, TEAMS, NOW)).toContain('One more code can be issued');
+    expect(buildSeriesStatus(series, TEAMS, NOW)).not.toContain('No more codes');
   });
 
   it('says why, and names the remedies, once the allowance is spent', () => {
@@ -374,35 +362,113 @@ describe('the code allowance', () => {
     expect(status).toContain('custom game');
   });
 
-  it('leaves Generate Next Game live at zero - it asks for the next game', () => {
-    // The allowance is per game and clears on a result, so a captain reporting
-    // and then pressing this is the ordinary way out. Greying it blocked that.
-    expect(labelsOfControl(spent())).toContain('Generate Next Game');
-    expect(generateIsDisabled(spent())).toBe(false);
-  });
-
   it('counts only the codes issued since the last recorded game', () => {
     // The first two belong to a game that is now in the books. Counting those
-    // would read as spent and grey the button out with a code still owed.
+    // would read as spent with a code still owed for the game in progress.
     const series = aSeries({
       tournamentCodes: [aCode(1, ago(5000)), aCode(2, ago(4000)), aCode(3, ago(1000))],
       games: [aGame(1, 11, 2)],
       lastGameAt: ago(3000),
     });
     expect(buildSeriesStatus(series, TEAMS, NOW)).not.toContain('No more codes');
+  });
+
+  it('stays quiet when the count cannot be worked out', () => {
+    // A code with no createdAt makes the count a guess, and a guess that reads
+    // low would announce a limit dennys is not applying.
+    const series = aSeries({ tournamentCodes: [aCode(1), aCode(2)] });
+    expect(buildSeriesStatus(series, TEAMS, NOW)).not.toContain('No more codes');
+  });
+});
+
+/**
+ * One game at a time (todd-bot#129). The next code is unlocked by reporting the
+ * current game, which is also the thing that clears dennys's code allowance -
+ * so every code counted since the last result belongs to the game in progress,
+ * and the allowance line above can be trusted to mean what it says.
+ */
+describe('generating the next game', () => {
+  const USER = '123456789012345678';
+  const labelsOfControl = (series?: SeriesWithGames) =>
+    buttonsOf(buildControlRow(USER, seriesData, series)).map(b => b.label);
+  const generateIsDisabled = (series?: SeriesWithGames) =>
+    (buttonsOf(buildControlRow(USER, seriesData, series))[0] as { disabled?: boolean }).disabled ===
+    true;
+
+  /** A code is out and nobody has reported the game it was issued for. */
+  const inProgress = () =>
+    aSeries({ tournamentCodes: [aCode(1, ago(1000))], lastCodeIssuedAt: ago(1000) });
+
+  it('greys the button while a game is in progress', () => {
+    expect(labelsOfControl(inProgress())).toContain('Generate Next Game');
+    expect(generateIsDisabled(inProgress())).toBe(true);
+  });
+
+  it('says why it is greyed, and where the button that clears it is', () => {
+    // A disabled button explains nothing on its own, and a captain who cannot
+    // tell "not yet" from "broken" opens a ticket.
+    const status = buildSeriesStatus(inProgress(), TEAMS, NOW);
+    expect(status).toContain('Report the game in progress to unlock the next one');
+    expect(status).toContain('code message above');
+  });
+
+  it('frees the button once the captain reports the game', () => {
+    const series = aSeries({
+      tournamentCodes: [aCode(1, ago(2000))],
+      games: [aGame(1, 11, 1)],
+      lastCodeIssuedAt: ago(2000),
+      lastGameAt: ago(1000),
+    });
+    expect(generateIsDisabled(series)).toBe(false);
+    expect(buildSeriesStatus(series, TEAMS, NOW)).not.toContain('unlock the next one');
+  });
+
+  it('frees the button when Riot records the game with nobody pressing anything', () => {
+    // No game names the code - a Riot pull can land one without Todd hearing -
+    // so the ordering of the two timestamps is what says the game is in.
+    const series = aSeries({
+      tournamentCodes: [aCode(1, ago(2000))],
+      lastCodeIssuedAt: ago(2000),
+      lastGameAt: ago(1000),
+    });
     expect(generateIsDisabled(series)).toBe(false);
   });
 
-  it('stays quiet and leaves the button live when the count cannot be worked out', () => {
-    // A code with no createdAt makes the count a guess, and a guess that reads
-    // low locks captains out of a code they are owed. Dennys can refuse instead.
-    const series = aSeries({ tournamentCodes: [aCode(1), aCode(2)] });
-    expect(buildSeriesStatus(series, TEAMS, NOW)).not.toContain('No more codes');
+  it('frees the button when a custom was played instead', () => {
+    // A custom leaves a game with no code on it, so nothing ever names code 1.
+    const series = aSeries({
+      tournamentCodes: [aCode(1, ago(2000))],
+      games: [aGame(1, 11, null)],
+      lastCodeIssuedAt: ago(2000),
+      lastGameAt: ago(1000),
+    });
     expect(generateIsDisabled(series)).toBe(false);
+  });
+
+  it('is live at the start of a series, before any code exists', () => {
+    expect(generateIsDisabled(aSeries())).toBe(false);
   });
 
   it('leaves the button live when there is no series to read', () => {
     expect(generateIsDisabled()).toBe(false);
+  });
+
+  it('always leaves exactly one live button - never two, never none', () => {
+    // The greyed generate and "Code not working?" are gated on the same
+    // condition, so the row cannot end up with nothing a captain can press.
+    for (const series of [inProgress(), aSeries()]) {
+      const buttons = buttonsOf(buildControlRow(USER, seriesData, series)) as {
+        label: string;
+        disabled?: boolean;
+      }[];
+      expect(buttons.filter(b => b.disabled !== true)).toHaveLength(1);
+    }
+  });
+
+  it('does not offer a second code as the way past a game in progress', () => {
+    // "Code not working?" is there for a dead code, and it is the only door to
+    // a replacement - which is what keeps the allowance one game deep.
+    expect(labelsOfControl(inProgress())).toEqual(['Generate Next Game', 'Code not working?']);
   });
 });
 

--- a/test/seriesControl.test.ts
+++ b/test/seriesControl.test.ts
@@ -383,7 +383,7 @@ describe('the code allowance', () => {
 });
 
 /**
- * One game at a time (todd-bot#129). The next code is unlocked by reporting the
+ * One game at a time. The next code is unlocked by reporting the
  * current game, which is also the thing that clears dennys's code allowance -
  * so every code counted since the last result belongs to the game in progress,
  * and the allowance line above can be trusted to mean what it says.

--- a/test/seriesControl.test.ts
+++ b/test/seriesControl.test.ts
@@ -8,6 +8,7 @@ import {
   buildCodeLimitRow,
   buildControlRow,
   buildGameReportRow,
+  announceSeriesFinished,
   buildSeriesStatus,
   clearRecoveryButtons,
   clearSupersededCodes,
@@ -567,6 +568,67 @@ function makeThread(existing: FakeMessage[]) {
 }
 
 const row = () => buildControlRow('123456789012345678', seriesData);
+
+/**
+ * The form is what actually records the match - nothing Todd writes reaches the
+ * standings - so this message must land, and must land once.
+ */
+describe('announceSeriesFinished', () => {
+  const FORM = 'https://forms.gle/test-form';
+
+  it('posts the form with the warning that results are not recorded without it', async () => {
+    const thread = makeThread([]);
+    await announceSeriesFinished(thread, FORM);
+
+    expect(thread.sent).toHaveLength(1);
+    expect(thread.sent[0].content).toContain('The series is finished!');
+    expect(thread.sent[0].content).toContain('will NOT be recorded');
+    expect(thread.sent[0].content).toContain('winning captain');
+    expect(thread.sent[0].content).toContain(FORM);
+  });
+
+  it('takes the form from config, so a new season does not need a deploy', async () => {
+    const thread = makeThread([]);
+    await announceSeriesFinished(thread, 'https://forms.gle/next-season');
+
+    expect(thread.sent[0].content).toContain('https://forms.gle/next-season');
+  });
+
+  it('carries no buttons - the form is the only action left', async () => {
+    const thread = makeThread([]);
+    await announceSeriesFinished(thread, FORM);
+
+    expect(thread.sent[0].components).toEqual([]);
+  });
+
+  it('says it once, however many times the series is read as complete', async () => {
+    // A correction reported after the series closed re-runs this path.
+    const thread = makeThread([]);
+    await announceSeriesFinished(thread, FORM);
+    const posted = makeMessage('100', thread.sent[0].content, false);
+    const second = makeThread([posted]);
+    await announceSeriesFinished(second, FORM);
+
+    expect(second.sent).toHaveLength(0);
+  });
+
+  it('is not confused by the code messages already in the thread', async () => {
+    // Both start with "# ", which is why the marker is the whole first phrase.
+    const thread = makeThread([makeGameMessage('1', 1, 9), makeGameMessage('2', 2, 10)]);
+    await announceSeriesFinished(thread, FORM);
+
+    expect(thread.sent).toHaveLength(1);
+  });
+
+  it('posts anyway when the thread cannot be read', async () => {
+    // A duplicate reminder costs a scroll; staying quiet costs the match result.
+    const thread = makeThread([]);
+    thread.fetch.mockRejectedValueOnce(new Error('no permission'));
+    await announceSeriesFinished(thread, FORM);
+
+    expect(thread.sent).toHaveLength(1);
+  });
+});
 
 describe('postSeriesControl', () => {
   let oldControl: FakeMessage;

--- a/test/tournament.test.ts
+++ b/test/tournament.test.ts
@@ -499,7 +499,7 @@ describe('dennys refusing a code because the allowance is spent', () => {
     const labels = (threadComponents[0][0] as any)
       .toJSON()
       .components.map((b: { label: string }) => b.label);
-    expect(labels).toEqual(['Report Game 1', 'Go play a custom game']);
+    expect(labels).toEqual(['Verify Game 1 Stats', 'Go play a custom game']);
   });
 
   it('points the report button at the code still outstanding', async () => {
@@ -604,7 +604,7 @@ describe('the thread ends with the controls', () => {
       label: string;
       custom_id: string;
     }[];
-    expect(button.label).toBe('Report Game 1');
+    expect(button.label).toBe('Verify Game 1 Stats');
     const parsed = parseButtonData(button.custom_id);
     expect(parsed.tag).toBe('report_result');
     // The code dennys just issued, and the game number the thread is showing.


### PR DESCRIPTION
## Why

A live series showed *"No more codes can be issued for this game — 2 have already gone out"* when one code had gone out for game 1 and one for game 2, with neither reported. The arithmetic was right and the sentence was wrong: Dennys counts codes since the last **result**, not per game number, so both codes counted — but a captain reads "this game" as the game in front of them, which had had exactly one. A series-wide condition was being reported as a per-game one.

Counting differently would not have fixed it. Todd is the only party that knows code A was for game 1 and code B was for game 2; Dennys has no game number on a code at all. Any count Todd invented would have promised codes Dennys then refused.

The real gap was upstream: nothing stopped a series from getting a code for the next game while the current one was unreported. That is also what made the allowance uncountable, and it left games silently unreported all the way to the end of a series.

Separately, two things at the end of a series: the button that files a result read **Report Game N**, which sounds like filing a complaint rather than confirming the stats landed; and nothing in the thread ever mentioned the post-game form, which is the thing that actually records the match in the standings.

## Solution

**Generate Next Game is greyed while a game is in progress**, and reporting that game frees it. `buildControlRow` gates it on `hasOutstandingCode` — the same predicate that shows **Code not working?** — so the row always carries exactly one live button, never two and never none. "Reported" means any of the three ways a game lands, because the predicate reads the series rather than the clicks: the captain filing it, Riot's callback recording it with nobody pressing anything, or a custom being reported (which records a game with no code on it, so only the timestamp ordering shows it).

That makes the allowance honest. Every code counted since the last result now belongs to the game in progress, so the zero line means what it says — and zero is only reachable through **Code not working? → Generate a new one**, which is the one door to a second code for the same game. The *"one more code can be issued"* line goes: under a two-code cap it fired on every game the moment its code was issued, and the greyed button now carries that meaning. A disabled button explains nothing on its own, so the status line says *"Report the game in progress to unlock the next one — use the Verify Stats button on its code message above."*

The report button is now **Verify Game N Stats**, and the three status lines that point at it follow the label rather than sending captains hunting for a "Report" button that no longer exists. The `report_result` tag and its wire encoding are untouched, so buttons already live in existing threads keep working.

`announceSeriesFinished` posts the post-game form the moment `series.completed` comes back true, before the control message so the controls stay last, and with no buttons — the form is the only action left. It fires on two paths, not one: the result that closes the series, and the *"already recorded"* decline, because Riot answering the final game closes a series with nobody reporting anything and a captain pressing Verify Stats is often the first moment Todd could know. It is posted once, guarded by scanning for `FINISHED_MARKER` rather than by "did this click complete the series", for that same reason. `POST_GAME_FORM_URL` is optional and defaults to the current form: a deploy that has never heard of the variable still boots, and a new season is a config change rather than a deploy.

## Acceptance Criteria

- Generate Next Game is greyed while a game is in progress and freed by reporting it — by the captain, by Riot recording it, or by a custom being reported
- The row always leaves exactly one live button; "Code not working?" is the only route to a second code for the same game
- The status line says why the button is greyed and where the button that clears it is
- The allowance line no longer fires for codes belonging to different games, and the "one more code" line is gone
- The report button reads **Verify Game N Stats**, and every line pointing at it uses the same words
- A finished series gets the post-game form once, with the warning that results are not recorded without it, above the control message and carrying no buttons
- It also lands when Riot closed the series with nobody reporting, and is not repeated on a later correction
- `POST_GAME_FORM_URL` unset or blank keeps the current form and never blocks boot

**Verification:** 12 new cases fail against pre-fix `src/` for the form, and 3 for the generation lock, across `test/seriesControl.test.ts`, `test/reportResult.test.ts` and `test/config.test.ts`. Full suite 423 passing, `npm run typecheck` clean, no new lint warnings. Docs: new *One game at a time* and *When the series finishes* sections in `docs/ARCHITECTURE.md`, the button rows and thread contents in `docs/COMMANDS.md`, the optional-vars table in `docs/DEVELOPMENT.md`, and a commented line in `.env.example`.

Follows up #128.