### PR TITLE
fix: Catch the thread up when Riot confirms a game

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -435,6 +435,16 @@ looking the shortcode up in `tournamentCodes[]`, and only falls back to the
 button's copy when the shortcode is not on the series at all. Trusting the button
 there would leave the answer resting on the id the request deliberately avoided.
 
+Whichever way the game lands, **the thread is brought into line the same way**.
+`catchThreadUp` is the one function both paths end in — the captain claiming a
+winner and Riot answering for the code are the same event as far as the thread is
+concerned, so the sweeps, the awaiting-report list, the finish message and the
+control message all run for both. They did not at first: the verify path retired
+the report buttons and stopped, which left a game Riot had just confirmed showing
+*"Report the game in progress to unlock the next one"* with Generate Next Game
+still greyed against a game that was over. Two code paths doing the same job by
+hand is what let them drift, so now there is only one.
+
 That resolved id is also what the **winner buttons** are minted with, rather than
 the target being passed through from the button that opened the picker. Those
 buttons are what call `/results`, and a result naming the wrong code is credited

--- a/src/buttons/handlers/reportResult.ts
+++ b/src/buttons/handlers/reportResult.ts
@@ -26,6 +26,7 @@ import {
 import type { ControlThread } from '../../seriesControl.ts';
 import { safeDefer, safeInteractionError } from '../../interactionSafety.ts';
 import { config } from '../../config.ts';
+import { SeriesData } from '../../types/toddData.ts';
 import log from 'loglevel';
 
 const logger = log.getLogger('reportResult');
@@ -33,6 +34,65 @@ logger.setLevel('info');
 
 const mayAct = (interaction: ButtonInteraction, originalUserId: string, enemyCaptainId: string) =>
   interaction.user.id === originalUserId || interaction.user.id === enemyCaptainId;
+
+/**
+ * Brings the thread into line with what dennys now holds.
+ *
+ * Both ways a game becomes recorded end here, and that is the whole point of it
+ * being one function: the captain claiming a winner and Riot answering for the
+ * code are the same event as far as the thread is concerned, and the status line
+ * and the buttons have to say so either way.
+ *
+ * They did not. The verify path retired the report buttons and stopped, so a
+ * game Riot had just confirmed left the status still asking for a result and
+ * Generate Next Game still greyed against a game that was over - the series had
+ * moved on and the only thing that said so was a message nobody could see.
+ *
+ * `retireCustomFor` is the game number a custom was just reported for, or null.
+ * A custom records a game with no code on it, so reconcileGameButtons can never
+ * reach its button and retiring by number is what closes that gap.
+ *
+ * The order is load-bearing: the sweeps run before the thread is read for what
+ * is still awaiting a result, so the game just recorded is not counted among
+ * them, and the control message is posted last so it stays at the bottom.
+ */
+async function catchThreadUp(
+  scan: ControlThread,
+  series: SeriesWithGames,
+  teams: [Team, Team],
+  seriesData: SeriesData,
+  originalUserId: string,
+  retireCustomFor: number | null,
+): Promise<void> {
+  // Retires the report button on every game dennys now holds - the one just
+  // recorded, and any Riot has answered since the thread was last touched.
+  await reconcileGameButtons(scan, series);
+
+  // A recorded game is the way past whatever the ⚠️ rows were offering a way
+  // past, so those retire on any result.
+  await clearRecoveryButtons(scan);
+
+  if (retireCustomFor != null) await retireGameButtons(scan, retireCustomFor);
+
+  // Only true because the shared scan carries the sweeps' edits forward.
+  const awaiting = await gamesAwaitingReport(scan, series);
+
+  // Before the control message, which has to stay last in the thread.
+  if (series.completed) {
+    await announceSeriesFinished(scan, config.POST_GAME_FORM_URL);
+  }
+
+  await postSeriesControl(
+    scan,
+    buildSeriesStatus(
+      series,
+      teams.map(team => ({ id: team.id, name: team.name })),
+      Date.now(),
+      awaiting,
+    ),
+    [buildControlRow(originalUserId, seriesData, series)],
+  );
+}
 
 /**
  * What to say instead of opening the picker, when the stats are already in.
@@ -204,20 +264,22 @@ export async function handleReportResult(interaction: ButtonInteraction) {
         components: [],
       });
 
-      // Retire the button that should not still have been there - for the other
-      // captain too, rather than leaving them to press it and read the same
-      // refusal. Riot's callback lands without anyone pressing anything, so
-      // this is the first chance Todd has had to notice.
+      // The same catch-up a self-reported result gets. Riot answering for the
+      // code moves the series on exactly as much as a captain claiming it does,
+      // so the status line and the buttons have to move with it - for both
+      // captains, not just whoever pressed.
       const thread = interaction.channel;
       if (thread && 'send' in thread) {
-        const scan = shareThreadScan(thread as unknown as ControlThread);
-        await reconcileGameButtons(scan, series);
-
-        // Riot answering the final game closes the series without anyone
-        // reporting it, so this press is the first time Todd could have known.
-        if (series.completed) {
-          await announceSeriesFinished(scan, config.POST_GAME_FORM_URL);
-        }
+        await catchThreadUp(
+          shareThreadScan(thread as unknown as ControlThread),
+          series,
+          [team1, team2],
+          seriesData,
+          data.originalUserId,
+          // Nothing to retire by number: this game has a code, so the sweep
+          // above reaches its button.
+          null,
+        );
       }
       return;
     }
@@ -357,49 +419,18 @@ async function report(interaction: ButtonInteraction, winner: 'team1' | 'team2')
         });
       }
 
-      // The four sweeps below have to run in this order and cannot be fired in
-      // parallel, so they shared five sequential fetches of the same fifty
-      // messages. One fetch now serves all of them.
-      const scan = shareThreadScan(thread as unknown as ControlThread);
-
-      // Retires the report button on every game dennys now holds - the one just
-      // written, and any Riot has answered since the thread was last touched.
-      await reconcileGameButtons(scan, series);
-
-      // A recorded game is the way past whatever the ⚠️ rows were offering a way
-      // past, so those retire on any result.
-      await clearRecoveryButtons(scan);
-
-      // A custom records a game with no code on it, so reconcile above can never
-      // reach either the custom's own button or the dead code's. Retiring by
-      // game number is what closes that gap - and only once the custom is
-      // genuinely on record, since a swallowed report still needs filing.
-      if (codeId == null && !swallowed && target) {
-        await retireGameButtons(scan, target.gameNumber);
-      }
-
-      // After the three sweeps above, so the game just reported is not counted
-      // among the ones still waiting - which is only true because the shared
-      // scan carries their edits forward.
-      const awaiting = await gamesAwaitingReport(scan, series);
-
-      // Before the control message, which has to stay last in the thread.
-      if (series.completed) {
-        await announceSeriesFinished(scan, config.POST_GAME_FORM_URL);
-      }
-
-      await postSeriesControl(
-        scan,
-        buildSeriesStatus(
-          series,
-          [
-            { id: team1.id, name: team1.name },
-            { id: team2.id, name: team2.name },
-          ],
-          Date.now(),
-          awaiting,
-        ),
-        [buildControlRow(data.originalUserId, seriesData, series)],
+      // The sweeps have to run in this order and cannot be fired in parallel, so
+      // they shared five sequential fetches of the same fifty messages. One
+      // fetch now serves all of them.
+      await catchThreadUp(
+        shareThreadScan(thread as unknown as ControlThread),
+        series,
+        [team1, team2],
+        seriesData,
+        data.originalUserId,
+        // Only once the custom is genuinely on record: a swallowed report still
+        // needs filing, so its button has to stay.
+        codeId == null && !swallowed && target ? target.gameNumber : null,
       );
     }
   } catch (error) {

--- a/test/reportResult.test.ts
+++ b/test/reportResult.test.ts
@@ -115,7 +115,7 @@ const { handleReportResult, handleReportTeam1Won } = await import(
   '../src/buttons/handlers/reportResult.ts'
 );
 const { createButtonData, parseButtonData } = await import('../src/buttons/button.ts');
-const { buildControlRow, CUSTOM_MARKER, RECOVERY_MARKER, STALE_CODE_MS } = await import(
+const { buildControlRow, CONTROL_MARKER, CUSTOM_MARKER, RECOVERY_MARKER, STALE_CODE_MS } = await import(
   '../src/seriesControl.ts'
 );
 
@@ -1010,5 +1010,123 @@ describe('what the winner buttons are told to write', () => {
     expect(reported).toEqual([
       { seriesId: 756, body: { winnerTeamId: 11, tournamentCodeId: 2 } },
     ]);
+  });
+});
+
+/**
+ * Riot answering for a code moves the series on exactly as much as a captain
+ * claiming a winner does. The thread has to move with it - for both captains,
+ * not just whoever pressed Verify.
+ *
+ * It did not: the verify path retired the report buttons and stopped, leaving
+ * the status line asking for a result dennys already held and Generate Next
+ * Game greyed against a game that was over.
+ */
+describe('the thread after Riot confirms a game', () => {
+  const codeMessage = (gameNumber: number, shortcode: string) =>
+    `# Game ${gameNumber} \n 🟦 A v.s. B 🟥\nCode: \`\`\`${shortcode}\`\`\`\n`;
+
+  /** Riot answered for game 1's code, so nothing is outstanding any more. */
+  const riotAnswered = () =>
+    aSeries({
+      tournamentCodes: [aCode(2)],
+      games: [aGame(1, 11, 2)],
+      lastCodeIssuedAt: '2026-08-09T12:00:00Z',
+      lastGameAt: '2026-08-09T12:20:00Z',
+    });
+
+  const verify = async () => {
+    refreshFinds = riotAnswered();
+    const interaction = makeInteraction(
+      'report_result',
+      ORIGINAL_USER,
+      [],
+      '2-1',
+      codeMessage(1, 'CODE2'),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleReportResult(interaction as any);
+  };
+
+  /** The control message the catch-up posts, if it posted one. */
+  const control = () => threadSends.find(s => s.content.startsWith(CONTROL_MARKER));
+
+  it('re-posts the series status', async () => {
+    await verify();
+    expect(control()).toBeDefined();
+  });
+
+  it('stops asking for a result dennys already has', async () => {
+    await verify();
+    expect(control()!.content).not.toContain('unlock the next one');
+  });
+
+  it('unlocks Generate Next Game', async () => {
+    // The flaw a captain actually hits: the game is over, Riot said so, and the
+    // only button that moves the series on is still greyed.
+    await verify();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [generate] = buttonsOf((control()!.components as any[])[0]) as {
+      label: string;
+      disabled?: boolean;
+    }[];
+    expect(generate.label).toBe('Generate Next Game');
+    expect(generate.disabled).not.toBe(true);
+  });
+
+  it('shows the score Riot just settled', async () => {
+    await verify();
+    expect(control()!.content).toContain('**Team 11** 1 – **Team 22** 0');
+  });
+
+  it('posts the form when Riot answering finished the series', async () => {
+    refreshFinds = { ...riotAnswered(), completed: true };
+    const interaction = makeInteraction(
+      'report_result',
+      ORIGINAL_USER,
+      [],
+      '2-1',
+      codeMessage(1, 'CODE2'),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleReportResult(interaction as any);
+
+    const finish = threadSends.findIndex(s => s.content.startsWith('# The series is finished!'));
+    const status = threadSends.findIndex(s => s.content.startsWith(CONTROL_MARKER));
+    expect(finish).toBeGreaterThanOrEqual(0);
+    // The controls stay last, below the form.
+    expect(status).toBeGreaterThan(finish);
+  });
+
+  it('retires the ⚠️ rows, which a recorded game is the way past', async () => {
+    refreshFinds = riotAnswered();
+    const recovery = aThreadMessage('9', `${RECOVERY_MARKER} Riot would not issue a code.`, 'x');
+    const interaction = makeInteraction(
+      'report_result',
+      ORIGINAL_USER,
+      [recovery],
+      '2-1',
+      codeMessage(1, 'CODE2'),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleReportResult(interaction as any);
+
+    expect(recovery.edit).toHaveBeenCalledWith({ components: [] });
+  });
+
+  it('says nothing extra when there is no game to confirm', async () => {
+    // Riot answered empty, so the picker opens and the thread is untouched -
+    // the series has not moved.
+    const interaction = makeInteraction(
+      'report_result',
+      ORIGINAL_USER,
+      [],
+      '2-1',
+      codeMessage(1, 'CODE2'),
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleReportResult(interaction as any);
+
+    expect(control()).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Why

Pressing **Verify Game N Stats** when Riot had the game told the captain the stats were in, retired the report buttons — and left the thread otherwise untouched. The status line went on saying *"Report the game in progress to unlock the next one"* for a result Dennys already held, and **Generate Next Game stayed greyed** against a game that was over. The series had moved on and nothing the captains could see said so, which left them with no working way forward.

The branch is older than the refresh work: it only ever ran when Riot's callback had already landed without anyone pressing anything, which was rare enough that the gap never showed. Making Verify actually re-ask Riot (#130) turned it into the ordinary outcome of the button.

The root cause is that the two ways a game gets recorded — the captain claiming a winner, and Riot answering for the code — brought the thread up to date in two separately hand-written blocks, and only one of them was complete.

## Solution

Both paths now end in one `catchThreadUp`: retire the buttons for games Dennys now holds, retire the ⚠️ recovery rows, retire a reported custom's button by number, read what is still awaiting a result, post the form if the series finished, then re-post the control message last so it stays at the bottom. The ordering was already load-bearing in the reporting path and is now stated in one place instead of being re-derived.

The verify path picks up two things beyond the status line that it was silently missing: `clearRecoveryButtons`, since a recorded game is the way past whatever a ⚠️ row was offering a way past, and the awaiting-report list.

## Acceptance Criteria

- A verify that finds the game re-posts the series status, with the score Riot just settled
- **Generate Next Game is live again** — the game is recorded, so nothing is in progress
- The status no longer asks for a result Dennys already holds
- The ⚠️ recovery rows retire, as they do on a self-reported result
- The post-game form still posts when Riot's answer finished the series, above the control message
- A verify that finds nothing leaves the thread alone — the series has not moved
- The self-report path behaves exactly as before

**Verification:** 6 new cases in `test/reportResult.test.ts`, all failing against `main`'s `reportResult.ts` and passing with the fix — including *"unlocks Generate Next Game"*, which is the flaw as reported. Full suite 479 passing, `npm run typecheck` clean, no new lint warnings. `docs/ARCHITECTURE.md` gains the `catchThreadUp` rule under *Verifying a game against Riot*.

Follows up #130.